### PR TITLE
refactor(settings): unify settings UI, autosaving AI config, editor focus fixes

### DIFF
--- a/src-tauri/src/commands/ai.rs
+++ b/src-tauri/src/commands/ai.rs
@@ -14,7 +14,7 @@ const MODEL_SETTING: &str = "ai.model";
 #[derive(serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AiConfig {
-    pub has_api_key: bool,
+    pub api_key: String,
     pub base_url: String,
     pub protocol: Protocol,
     pub model: String,
@@ -45,16 +45,16 @@ async fn stored_base_url(state: &AppState, protocol: Protocol) -> AppResult<Stri
 
 #[tauri::command]
 pub async fn ai_get_config(state: State<'_, AppState>) -> AppResult<AiConfig> {
-    let has_api_key = settings_repo::get(&state.db, API_KEY_SETTING)
+    let api_key = settings_repo::get(&state.db, API_KEY_SETTING)
         .await?
-        .is_some_and(|v| !v.is_empty());
+        .unwrap_or_default();
     let protocol = stored_protocol(&state).await?;
     let base_url = stored_base_url(&state, protocol).await?;
     let model = settings_repo::get(&state.db, MODEL_SETTING)
         .await?
         .unwrap_or_default();
     Ok(AiConfig {
-        has_api_key,
+        api_key,
         base_url,
         protocol,
         model,
@@ -68,9 +68,12 @@ pub async fn ai_set_config(state: State<'_, AppState>, input: AiConfigInput) -> 
     }
     settings_repo::set(&state.db, BASE_URL_SETTING, input.base_url.trim()).await?;
     settings_repo::set(&state.db, PROTOCOL_SETTING, input.protocol.as_str()).await?;
-    if let Some(key) = input.api_key.filter(|k| !k.is_empty()) {
-        settings_repo::set(&state.db, API_KEY_SETTING, &key).await?;
-    }
+    settings_repo::set(
+        &state.db,
+        API_KEY_SETTING,
+        input.api_key.as_deref().unwrap_or_default().trim(),
+    )
+    .await?;
     Ok(())
 }
 

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -18,6 +18,7 @@ export * from "./badge";
 export * from "./spinner";
 export * from "./kbd";
 export * from "./empty-state";
+export * from "./section-header";
 export * from "./segmented-control";
 export * from "./select";
 export * from "./resize-handle";

--- a/src/components/ui/section-header.tsx
+++ b/src/components/ui/section-header.tsx
@@ -1,0 +1,25 @@
+import type { ReactNode } from "react";
+
+interface SectionHeaderProps {
+  title: ReactNode;
+  description?: ReactNode;
+  actions?: ReactNode;
+}
+
+export function SectionHeader({
+  title,
+  description,
+  actions,
+}: SectionHeaderProps) {
+  return (
+    <div>
+      <div className="flex items-center gap-1.5">
+        <h3 className="text-sm font-medium text-foreground">{title}</h3>
+        {actions}
+      </div>
+      {description && (
+        <p className="mt-1 text-sm text-muted-foreground">{description}</p>
+      )}
+    </div>
+  );
+}

--- a/src/features/ai/AssistantPanel.tsx
+++ b/src/features/ai/AssistantPanel.tsx
@@ -60,7 +60,7 @@ export function AssistantPanel({ width }: { width: number }) {
   const { t } = useI18n();
   const { data: config } = useAiConfig();
   const setModel = useSetAiModel();
-  const configured = Boolean(config?.hasApiKey);
+  const configured = Boolean(config?.apiKey);
   const { data: fetchedModels } = useAiModels(configured);
   const toggleAux = useLayoutStore((s) => s.toggleAux);
   const openSettings = useTabsStore((s) => s.openSettings);

--- a/src/features/ai/api.ts
+++ b/src/features/ai/api.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { ipc } from "@/lib/ipc";
-import type { AiProtocol } from "@/types/models";
+import type { AiConfig, AiProtocol } from "@/types/models";
 
 const configKey = ["ai", "config"] as const;
 const modelsKey = ["ai", "models"] as const;
@@ -26,8 +26,15 @@ export function useSetAiConfig() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: ipc.ai.setConfig,
-    onSuccess: () => {
-      qc.invalidateQueries({ queryKey: configKey });
+    onSuccess: (_, input) => {
+      qc.setQueryData<AiConfig>(configKey, (prev) =>
+        prev
+          ? {
+              ...input,
+              model: prev.protocol === input.protocol ? prev.model : "",
+            }
+          : prev,
+      );
       qc.invalidateQueries({ queryKey: modelsKey });
     },
   });

--- a/src/features/settings/SettingsPage.tsx
+++ b/src/features/settings/SettingsPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Info, Minus, Palette, Plus, RefreshCw, Sparkles } from "lucide-react";
 
 import {
@@ -7,6 +7,7 @@ import {
   Input,
   Kbd,
   ScrollArea,
+  SectionHeader,
   SegmentedControl,
   Select,
   Tooltip,
@@ -44,7 +45,7 @@ export function SettingsPage({ section }: { section: SettingsSection }) {
   const setSection = useTabsStore((s) => s.setSettingsSection);
 
   return (
-    <div className="settings-page flex h-full flex-col bg-background">
+    <div className="flex h-full flex-col bg-background">
       <div className="shrink-0 border-b border-border p-3">
         <SegmentedControl
           value={section}
@@ -65,7 +66,7 @@ export function SettingsPage({ section }: { section: SettingsSection }) {
       </div>
 
       <ScrollArea className="min-h-0 min-w-0 flex-1">
-        <div className="settings-content flex min-w-0 max-w-2xl flex-col gap-6 p-6">
+        <div className="flex w-full min-w-0 flex-col gap-6 p-6">
           {section === "appearance" && <AppearanceSection />}
           {section === "ai" && <AiSection />}
           {section === "sync" && <SyncSection />}
@@ -80,27 +81,41 @@ function AppearanceSection() {
   const { t, locale, setLocale } = useI18n();
   const { theme, setTheme } = useTheme();
 
-  return (
-    <div className="flex flex-col gap-6">
-      <div>
-        <h3 className="text-sm font-medium text-foreground">
-          {t("settings.appearance.themeTitle")}
-        </h3>
-        <p className="mt-1 text-sm text-muted-foreground">
-          {t("settings.appearance.themeDescription")}
-        </p>
-      </div>
+  const groups = [
+    {
+      labelKey: "settings.appearance.darkThemes" as TKey,
+      themes: THEMES.filter((candidate) => candidate.appearance === "dark"),
+    },
+    {
+      labelKey: "settings.appearance.lightThemes" as TKey,
+      themes: THEMES.filter((candidate) => candidate.appearance === "light"),
+    },
+  ];
 
-      <div className="grid grid-cols-[repeat(auto-fit,minmax(min(100%,11rem),1fr))] gap-3">
-        {THEMES.map((candidate) => (
-          <ThemeCard
-            key={candidate.id}
-            theme={candidate}
-            active={candidate.id === theme.id}
-            onSelect={() => setTheme(candidate.id)}
-          />
-        ))}
-      </div>
+  return (
+    <div className="flex flex-col gap-4">
+      <SectionHeader
+        title={t("settings.appearance.themeTitle")}
+        description={t("settings.appearance.themeDescription")}
+      />
+
+      {groups.map((group) => (
+        <div key={group.labelKey} className="flex flex-col gap-2">
+          <p className="text-xs font-medium text-muted-foreground">
+            {t(group.labelKey)}
+          </p>
+          <div className="grid grid-cols-[repeat(auto-fill,minmax(min(100%,11rem),1fr))] gap-3">
+            {group.themes.map((candidate) => (
+              <ThemeCard
+                key={candidate.id}
+                theme={candidate}
+                active={candidate.id === theme.id}
+                onSelect={() => setTheme(candidate.id)}
+              />
+            ))}
+          </div>
+        </div>
+      ))}
 
       <Field
         label={t("settings.appearance.language")}
@@ -257,37 +272,53 @@ function AiForm({ config }: { config: AiConfig }) {
   const setConfig = useSetAiConfig();
   const [protocol, setProtocol] = useState<AiProtocol>(config.protocol);
   const [baseUrl, setBaseUrl] = useState(config.baseUrl);
-  const [apiKey, setApiKey] = useState("");
+  const [apiKey, setApiKey] = useState(config.apiKey);
+  const mutate = setConfig.mutate;
+  const skipSave = useRef(true);
+  const pendingSave = useRef<{
+    baseUrl: string;
+    protocol: AiProtocol;
+    apiKey: string;
+  } | null>(null);
 
   const changeProtocol = (next: AiProtocol) => {
     setProtocol(next);
     setBaseUrl(defaultBaseUrl(next));
   };
 
-  const save = async () => {
-    try {
-      await setConfig.mutateAsync({
-        baseUrl,
-        protocol,
-        apiKey: apiKey || undefined,
-      });
-      setApiKey("");
-      toast.success(t("settings.ai.saved"));
-    } catch (err) {
-      toast.error(t("settings.ai.saveError"), errorMessage(err));
+  useEffect(() => {
+    if (skipSave.current) {
+      skipSave.current = false;
+      return;
     }
-  };
+    pendingSave.current = { baseUrl, protocol, apiKey };
+    const timer = setTimeout(() => {
+      pendingSave.current = null;
+      mutate(
+        { baseUrl, protocol, apiKey },
+        {
+          onError: (err) =>
+            toast.error(t("settings.ai.saveError"), errorMessage(err)),
+        },
+      );
+    }, 500);
+    return () => clearTimeout(timer);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [protocol, baseUrl, apiKey]);
+
+  useEffect(
+    () => () => {
+      if (pendingSave.current) mutate(pendingSave.current);
+    },
+    [mutate],
+  );
 
   return (
     <div className="flex flex-col gap-4">
-      <div>
-        <h3 className="text-sm font-medium text-foreground">
-          {t("settings.ai.title")}
-        </h3>
-        <p className="mt-1 text-sm text-muted-foreground">
-          {t("settings.ai.description")}
-        </p>
-      </div>
+      <SectionHeader
+        title={t("settings.ai.title")}
+        description={t("settings.ai.description")}
+      />
 
       <Field label={t("settings.ai.protocolLabel")}>
         <Select
@@ -317,31 +348,16 @@ function AiForm({ config }: { config: AiConfig }) {
 
       <Field
         label={t("settings.ai.apiKeyLabel")}
-        hint={
-          config.hasApiKey
-            ? t("settings.ai.apiKeyHintSaved")
-            : t("settings.ai.apiKeyHint")
-        }
+        hint={t("settings.ai.apiKeyHint")}
       >
         <Input
-          type="password"
           value={apiKey}
           onChange={(e) => setApiKey(e.target.value)}
-          placeholder={
-            config.hasApiKey ? t("settings.ai.apiKeyPlaceholderSaved") : "sk-…"
-          }
+          placeholder="sk-…"
           autoComplete="off"
+          spellCheck={false}
         />
       </Field>
-
-      <Button
-        className="self-start"
-        onClick={save}
-        disabled={!baseUrl || (!apiKey && !config.hasApiKey)}
-        loading={setConfig.isPending}
-      >
-        {t("common.save")}
-      </Button>
     </div>
   );
 }

--- a/src/features/sftp/FileEditor.tsx
+++ b/src/features/sftp/FileEditor.tsx
@@ -33,6 +33,7 @@ import { HardDrive, Server } from "lucide-react";
 
 import { Spinner } from "@/components/ui";
 import { useTabsStore, type FileTab } from "@/workbench/tabs";
+import { registerFileEditor, unregisterFileEditor } from "./editor-registry";
 
 const editorTheme = EditorView.theme({
   "&": {
@@ -459,7 +460,8 @@ function CodeEditor({ tabId, title }: { tabId: string; title: string }) {
       }),
       parent: hostRef.current!,
     });
-    view.focus();
+    registerFileEditor(tabId, view);
+    if (useTabsStore.getState().activeId === tabId) view.focus();
 
     let cancelled = false;
     const description = LanguageDescription.matchFilename(languages, title);
@@ -473,6 +475,7 @@ function CodeEditor({ tabId, title }: { tabId: string; title: string }) {
 
     return () => {
       cancelled = true;
+      unregisterFileEditor(tabId);
       view.destroy();
     };
   }, [tabId, title]);

--- a/src/features/sftp/editor-registry.ts
+++ b/src/features/sftp/editor-registry.ts
@@ -1,0 +1,16 @@
+import type { EditorView } from "@codemirror/view";
+
+const registry = new Map<string, EditorView>();
+
+export function registerFileEditor(id: string, view: EditorView) {
+  registry.set(id, view);
+}
+
+export function unregisterFileEditor(id: string) {
+  registry.delete(id);
+}
+
+export function focusFileEditor(id: string | null) {
+  if (!id) return;
+  registry.get(id)?.focus();
+}

--- a/src/features/sync/SetupView.tsx
+++ b/src/features/sync/SetupView.tsx
@@ -13,6 +13,7 @@ import {
   Field,
   Input,
   PasswordInput,
+  SectionHeader,
   Spinner,
   Switch,
 } from "@/components/ui";
@@ -81,16 +82,12 @@ export function SetupView({ status }: { status: SyncStatus }) {
 
   return (
     <div className="flex flex-col gap-4">
-      <div>
-        <h3 className="text-sm font-medium text-foreground">
-          {t("settings.sync.title")}
-        </h3>
-        <p className="mt-1 text-sm text-muted-foreground">
-          {t("settings.sync.description")}
-        </p>
-      </div>
+      <SectionHeader
+        title={t("settings.sync.title")}
+        description={t("settings.sync.description")}
+      />
 
-      <div className="grid grid-cols-[repeat(auto-fit,minmax(min(100%,11rem),1fr))] gap-2">
+      <div className="grid grid-cols-[repeat(auto-fill,minmax(min(100%,11rem),1fr))] gap-2">
         {SYNC_PROVIDERS.map((p) => {
           const Icon = p.icon;
           const active = p.kind === kind;

--- a/src/features/sync/SyncSection.tsx
+++ b/src/features/sync/SyncSection.tsx
@@ -13,6 +13,7 @@ import {
   DialogTitle,
   EmptyState,
   PasswordInput,
+  SectionHeader,
   Separator,
   Spinner,
   Tooltip,
@@ -116,14 +117,10 @@ function ConnectedCard({ status }: { status: SyncStatus }) {
 
   return (
     <div className="flex flex-col gap-4">
-      <div>
-        <h3 className="text-sm font-medium text-foreground">
-          {t("settings.sync.title")}
-        </h3>
-        <p className="mt-1 text-sm text-muted-foreground">
-          {t("settings.sync.connected.hint")}
-        </p>
-      </div>
+      <SectionHeader
+        title={t("settings.sync.title")}
+        description={t("settings.sync.connected.hint")}
+      />
 
       <div className="flex flex-wrap items-center gap-3 rounded-lg border border-input bg-surface px-4 py-3">
         <Icon className="size-6 shrink-0 text-foreground" />
@@ -184,71 +181,54 @@ function VersionsCard() {
     refetch,
   } = useSyncVersions(true);
   const [target, setTarget] = useState<SyncVersion | null>(null);
-  const [manualRefreshing, setManualRefreshing] = useState(false);
-  const showLoading = isLoading || manualRefreshing;
-  const visibleVersions = manualRefreshing ? undefined : versions;
-
-  const doRefresh = async () => {
-    setManualRefreshing(true);
-    try {
-      await refetch();
-    } finally {
-      setManualRefreshing(false);
-    }
-  };
 
   return (
     <div className="flex flex-col gap-4">
-      <div>
-        <div className="flex items-center gap-1.5">
-          <h3 className="text-sm font-medium text-foreground">
-            {t("settings.sync.versions.title")}
-          </h3>
+      <SectionHeader
+        title={t("settings.sync.versions.title")}
+        description={t("settings.sync.versions.description")}
+        actions={
           <Tooltip content={t("settings.sync.versions.refreshButton")}>
             <Button
               size="icon"
               variant="ghost"
               className="size-6"
-              onClick={() => void doRefresh()}
-              disabled={isFetching || manualRefreshing}
+              onClick={() => void refetch()}
+              disabled={isFetching}
               aria-label={t("settings.sync.versions.refreshButton")}
             >
               <RefreshCw
-                className={showLoading ? "size-3.5 animate-spin" : "size-3.5"}
+                className={
+                  isFetching && !isLoading
+                    ? "size-3.5 animate-spin"
+                    : "size-3.5"
+                }
               />
             </Button>
           </Tooltip>
-        </div>
-        <p className="mt-1 text-sm text-muted-foreground">
-          {t("settings.sync.versions.description")}
-        </p>
-      </div>
+        }
+      />
 
-      {showLoading && (
+      {isLoading && (
         <div className="flex items-center gap-2 py-6 text-sm text-muted-foreground">
           <Spinner />
           <span>{t("settings.sync.versions.loading")}</span>
         </div>
       )}
 
-      {!showLoading && isError && (
+      {!isLoading && isError && (
         <p className="text-sm text-destructive">
           {t("settings.sync.versions.loadError")}
         </p>
       )}
 
-      {!showLoading &&
-        !isError &&
-        (!visibleVersions || visibleVersions.length === 0) && (
-          <EmptyState
-            icon={History}
-            title={t("settings.sync.versions.empty")}
-          />
-        )}
+      {!isLoading && !isError && (!versions || versions.length === 0) && (
+        <EmptyState icon={History} title={t("settings.sync.versions.empty")} />
+      )}
 
-      {!!visibleVersions?.length && (
+      {!!versions?.length && (
         <ul className="flex flex-col divide-y divide-border overflow-hidden rounded-lg border border-input">
-          {visibleVersions.map((v, idx) => (
+          {versions.map((v, idx) => (
             <li
               key={v.id}
               className="flex flex-wrap items-center justify-between gap-3 px-3 py-2.5"
@@ -395,14 +375,10 @@ function FileBackupCard() {
 
   return (
     <div className="flex flex-col gap-4">
-      <div>
-        <h3 className="text-sm font-medium text-foreground">
-          {t("settings.sync.file.title")}
-        </h3>
-        <p className="mt-1 text-sm text-muted-foreground">
-          {t("settings.sync.file.description")}
-        </p>
-      </div>
+      <SectionHeader
+        title={t("settings.sync.file.title")}
+        description={t("settings.sync.file.description")}
+      />
 
       <div className="flex flex-wrap gap-2">
         <Button

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -553,6 +553,8 @@ export const en = {
       themeTitle: "Theme",
       themeDescription:
         "Choose how Sageport looks. Each theme styles the whole interface, including the terminal.",
+      darkThemes: "Dark themes",
+      lightThemes: "Light themes",
       language: "Language",
       languageHint: "Sets the display language of the app.",
       zoom: "Zoom",
@@ -565,17 +567,15 @@ export const en = {
     ai: {
       title: "AI provider",
       description:
-        "Bring your own API key. Works with Anthropic and any OpenAI compatible endpoint.",
+        "Bring your own API key. Works with Anthropic and any OpenAI compatible endpoint. Changes are saved automatically.",
       protocolLabel: "API format",
       protocol_openai: "OpenAI compatible",
       protocol_anthropic: "Anthropic compatible",
       baseUrlLabel: "Base URL",
       baseUrlHint: "OpenAI compatible endpoints usually end with /v1.",
       apiKeyLabel: "API key",
-      apiKeyHint: "Stored on this device only.",
-      apiKeyHintSaved: "A key is saved. Enter a new one to replace it.",
-      apiKeyPlaceholderSaved: "••••••••",
-      saved: "Configuration saved",
+      apiKeyHint:
+        "Leaves this device only inside encrypted backups when sync is enabled.",
       saveError: "Failed to save configuration",
     },
     sync: {

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -541,6 +541,8 @@ export const zhCN: Dictionary = {
       themeTitle: "主题",
       themeDescription:
         "选择 Sageport 的外观。每套主题都会应用到整个界面，包括终端。",
+      darkThemes: "深色主题",
+      lightThemes: "浅色主题",
       language: "语言",
       languageHint: "设置应用的显示语言。",
       zoom: "缩放",
@@ -552,17 +554,14 @@ export const zhCN: Dictionary = {
     ai: {
       title: "AI 服务商",
       description:
-        "使用你自己的 API 密钥，支持 Anthropic 和任意 OpenAI 兼容接口。",
+        "使用你自己的 API 密钥，支持 Anthropic 和任意 OpenAI 兼容接口。修改会自动保存。",
       protocolLabel: "接口格式",
       protocol_openai: "OpenAI 兼容",
       protocol_anthropic: "Anthropic 兼容",
       baseUrlLabel: "接口地址",
       baseUrlHint: "OpenAI 兼容接口的地址通常以 /v1 结尾。",
       apiKeyLabel: "API 密钥",
-      apiKeyHint: "仅存储在本设备上。",
-      apiKeyHintSaved: "已保存密钥，输入新密钥可替换。",
-      apiKeyPlaceholderSaved: "••••••••",
-      saved: "配置已保存",
+      apiKeyHint: "仅在启用同步时随加密备份离开本设备。",
       saveError: "保存配置失败",
     },
     sync: {

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -260,7 +260,7 @@ export const ipc = {
     setConfig: (input: {
       baseUrl: string;
       protocol: AiProtocol;
-      apiKey?: string;
+      apiKey: string;
     }) => invoke<void>("ai_set_config", { input }),
 
     listModels: () => invoke<string[]>("ai_list_models"),

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -302,10 +302,3 @@
 .dark .tok-heading {
   color: #569cd6;
 }
-
-@layer components {
-  .settings-page {
-    container-type: inline-size;
-    min-width: 36rem;
-  }
-}

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -246,7 +246,7 @@ export interface SnippetInput {
 export type AiProtocol = "openai" | "anthropic";
 
 export interface AiConfig {
-  hasApiKey: boolean;
+  apiKey: string;
   baseUrl: string;
   protocol: AiProtocol;
   model: string;

--- a/src/workbench/EditorArea.tsx
+++ b/src/workbench/EditorArea.tsx
@@ -10,6 +10,7 @@ import {
 import { useI18n } from "@/i18n";
 import { cn } from "@/lib/utils";
 import { SettingsPage } from "@/features/settings/SettingsPage";
+import { focusFileEditor } from "@/features/sftp/editor-registry";
 import { FileEditor } from "@/features/sftp/FileEditor";
 import { TerminalEditor } from "@/features/terminal/TerminalEditor";
 import { focusTerminal } from "@/features/terminal/registry";
@@ -75,6 +76,7 @@ export function EditorArea() {
       ?.querySelector(`[data-tab-id="${CSS.escape(activeId)}"]`)
       ?.scrollIntoView({ block: "nearest", inline: "nearest" });
     focusTerminal(activeId);
+    focusFileEditor(activeId);
   }, [activeId]);
 
   if (tabs.length === 0) return <Watermark />;


### PR DESCRIPTION
## 概述

按四个方向优化设置页与编辑区:

### 1. 设置内容 100% 宽度
- 移除设置内容的 `max-w-2xl`,内容占满整个页签宽度
- 移除 `.settings-page` 的 `min-width: 36rem` 与未使用的 `container-type`(窄窗口下不再被裁切)
- 主题卡片/同步提供商网格从 `auto-fit` 改为 `auto-fill`,全宽下卡片保持固定尺寸不被拉伸

### 2. 主题与外观
- 主题选择按「深色主题 / 浅色主题」分组展示,更易浏览(对齐 VSCode 主题选择器的分组习惯)
- 外观分区内间距与其他分区统一(gap-4)

### 3. 设置组件统一与体验优化
- 新增 `SectionHeader` 组件,统一各分区「标题 + 描述(+ 行内操作)」结构,替换 5 处手写重复布局
- **AI 设置去掉保存按钮**:改为修改后自动保存(500ms 防抖,卸载时兜底提交),与外观等其他分区行为一致;失败时 toast 提示
- **API 密钥明文显示**:后端 `AiConfig` 直接返回密钥(本就存于本地 DB),输入框不再用 password 类型,支持清空密钥
- `useSetAiConfig` 保存成功后直接写入查询缓存,避免自动保存期间的 refetch 竞态
- **同步备份历史去重转圈**:刷新时仅标题旁的刷新图标旋转,列表保持可见;仅首次加载显示下方的加载行,移除 `manualRefreshing` 状态
- 文案更新:AI 密钥提示由「仅存储在本设备上」修正为「仅在启用同步时随加密备份离开本设备」(密钥实际包含在加密同步备份内);中英文同步

### 4. 终端 / 文件编辑窗口展示逻辑修复
- **修复:切到文件页签时编辑器不获得焦点**——此前 `Cmd+S` 与输入在点击编辑器前均无效。新增 `editor-registry`(对齐终端 registry 模式),页签激活时聚焦对应 CodeMirror 实例
- **修复:后台文件页签抢焦点**——文件内容异步加载完成时无条件 `view.focus()`,若用户已切走会从当前终端抢走焦点;现仅在该页签处于激活状态时聚焦

## 验证
- `tsc`、`eslint --max-warnings 0`、`vitest`(44 通过,含 locale parity)、`prettier --check`、`cargo check/clippy/fmt`、`pnpm build` 全部通过
- GUI 截图验证受阻:本机 shell 无屏幕录制权限,`screencapture` 无法捕获窗口;本地正在运行的 `tauri dev` 实例已热加载全部改动,可直接肉眼确认