### PR TITLE
fix(settings): add min/max width constraints

### DIFF
--- a/src/features/settings/SettingsPage.tsx
+++ b/src/features/settings/SettingsPage.tsx
@@ -45,34 +45,37 @@ export function SettingsPage({ section }: { section: SettingsSection }) {
   const setSection = useTabsStore((s) => s.setSettingsSection);
 
   return (
-    <div className="flex h-full flex-col bg-background">
-      <div className="shrink-0 border-b border-border p-3">
-        <SegmentedControl
-          value={section}
-          onChange={setSection}
-          options={NAV.map((item) => {
-            const Icon = item.icon;
-            return {
-              value: item.id,
-              label: (
-                <span className="flex items-center justify-center gap-2">
-                  <Icon className="size-4 shrink-0" />
-                  <span className="truncate">{t(item.labelKey)}</span>
-                </span>
-              ),
-            };
-          })}
-        />
-      </div>
-
-      <ScrollArea className="min-h-0 min-w-0 flex-1">
-        <div className="flex w-full min-w-0 flex-col gap-6 p-6">
-          {section === "appearance" && <AppearanceSection />}
-          {section === "ai" && <AiSection />}
-          {section === "sync" && <SyncSection />}
-          {section === "about" && <AboutSection />}
+    <div className="settings-page h-full overflow-x-auto overflow-y-hidden bg-background">
+      <div className="flex h-full min-w-xl flex-col">
+        <div className="shrink-0 border-b border-border p-3">
+          <SegmentedControl
+            className="max-w-2xl"
+            value={section}
+            onChange={setSection}
+            options={NAV.map((item) => {
+              const Icon = item.icon;
+              return {
+                value: item.id,
+                label: (
+                  <span className="flex items-center justify-center gap-2">
+                    <Icon className="size-4 shrink-0" />
+                    <span className="truncate">{t(item.labelKey)}</span>
+                  </span>
+                ),
+              };
+            })}
+          />
         </div>
-      </ScrollArea>
+
+        <ScrollArea className="min-h-0 flex-1">
+          <div className="settings-content flex w-full max-w-2xl flex-col gap-6 p-6">
+            {section === "appearance" && <AppearanceSection />}
+            {section === "ai" && <AiSection />}
+            {section === "sync" && <SyncSection />}
+            {section === "about" && <AboutSection />}
+          </div>
+        </ScrollArea>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
Add width constraints to the settings page for better layout control and readability.

- Minimum width: 36rem (prevents content collapse on narrow windows)
- Maximum width: 42rem (keeps content readable on wide screens)
- Content aligns left with horizontal scroll support on constrained viewports

## Test plan
- [ ] Open settings page on narrow window and verify horizontal scroll appears
- [ ] Open settings page on wide window and verify max-width is respected and content is left-aligned
- [ ] Verify all settings sections display correctly