### PR TITLE
feat(terminal): split panes within terminal tabs

### DIFF
--- a/scripts/check-bundle.mjs
+++ b/scripts/check-bundle.mjs
@@ -17,8 +17,8 @@ const initialAssets = [
 
 // The workbench shell includes accessible dialog, tabs, and toast primitives.
 // Keep roughly the same headroom as the previous 650 kB budget after adding them.
-// Bumped again for the terminal split-pane toolbar's lazy-loaded action slot.
-const INITIAL_JS_BUDGET = 704 * 1024;
+// Bumped slightly for the terminal split-pane focus-follow bookkeeping.
+const INITIAL_JS_BUDGET = 701 * 1024;
 const lazyOnlyPrefixes = [
   "AssistantPanel-",
   "FileEditor-",

--- a/scripts/check-bundle.mjs
+++ b/scripts/check-bundle.mjs
@@ -17,7 +17,8 @@ const initialAssets = [
 
 // The workbench shell includes accessible dialog, tabs, and toast primitives.
 // Keep roughly the same headroom as the previous 650 kB budget after adding them.
-const INITIAL_JS_BUDGET = 700 * 1024;
+// Bumped again for the terminal split-pane toolbar's lazy-loaded action slot.
+const INITIAL_JS_BUDGET = 704 * 1024;
 const lazyOnlyPrefixes = [
   "AssistantPanel-",
   "FileEditor-",

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -15,7 +15,8 @@
     "opener:default",
     "os:default",
     "dialog:default",
-    "clipboard-manager:default",
+    "clipboard-manager:allow-read-text",
+    "clipboard-manager:allow-write-text",
     "process:default"
   ]
 }

--- a/src/features/ai/ToolActivity.tsx
+++ b/src/features/ai/ToolActivity.tsx
@@ -24,7 +24,7 @@ import {
   TOOL_LABEL_KEYS,
   TOOLS_REQUIRING_APPROVAL,
 } from "./tools";
-import { terminalTabs, useTabsStore } from "@/workbench/tabs";
+import { findPane, useTabsStore } from "@/workbench/tabs";
 
 type ToolLogItem = Extract<AgentLogItem, { kind: "tool" }>;
 
@@ -112,10 +112,7 @@ export function ToolActivity({
   const targetSessionId =
     typeof item.args.sessionId === "string" ? item.args.sessionId : undefined;
   const targetTitle = useTabsStore((state) =>
-    targetSessionId
-      ? terminalTabs(state.tabs).find((tab) => tab.id === targetSessionId)
-          ?.title
-      : undefined,
+    targetSessionId ? findPane(state.tabs, targetSessionId)?.title : undefined,
   );
 
   return (

--- a/src/features/ai/runner.test.ts
+++ b/src/features/ai/runner.test.ts
@@ -73,7 +73,7 @@ beforeEach(() => {
   useTabsStore.setState({
     tabs: [],
     activeId: null,
-    lastTerminalId: null,
+    lastPaneId: null,
     pendingCloseId: null,
   });
 });
@@ -222,15 +222,22 @@ describe("runAgentLoop", () => {
         {
           kind: "terminal",
           id: "terminal-1",
-          target: "ssh",
-          hostId: "host-1",
-          title: "Production",
-          status: "connected",
-          attempt: 0,
+          panes: [
+            {
+              id: "terminal-1",
+              target: "ssh",
+              hostId: "host-1",
+              title: "Production",
+              status: "connected",
+              attempt: 0,
+            },
+          ],
+          layout: { type: "leaf", paneId: "terminal-1" },
+          activePaneId: "terminal-1",
         },
       ],
       activeId: "terminal-1",
-      lastTerminalId: "terminal-1",
+      lastPaneId: "terminal-1",
     });
     chat
       .mockResolvedValueOnce({
@@ -267,15 +274,22 @@ describe("runAgentLoop", () => {
         {
           kind: "terminal",
           id: "terminal-1",
-          target: "ssh",
-          hostId: "host-1",
-          title: "Production",
-          status: "connected",
-          attempt: 0,
+          panes: [
+            {
+              id: "terminal-1",
+              target: "ssh",
+              hostId: "host-1",
+              title: "Production",
+              status: "connected",
+              attempt: 0,
+            },
+          ],
+          layout: { type: "leaf", paneId: "terminal-1" },
+          activePaneId: "terminal-1",
         },
       ],
       activeId: "terminal-1",
-      lastTerminalId: "terminal-1",
+      lastPaneId: "terminal-1",
     });
     chat
       .mockResolvedValueOnce({

--- a/src/features/ai/runner.ts
+++ b/src/features/ai/runner.ts
@@ -2,7 +2,7 @@ import { detectLocale } from "@/i18n/config";
 import { ipc } from "@/lib/ipc";
 import { errorCode, errorMessage } from "@/lib/toast";
 import type { AiChatMessage, AiModelLimits, AiToolCall } from "@/types/models";
-import { targetTerminalId, terminalTabs, useTabsStore } from "@/workbench/tabs";
+import { findPane, targetPaneId, useTabsStore } from "@/workbench/tabs";
 import {
   DEFAULT_CONTEXT_WINDOW_TOKENS,
   estimateTextTokens,
@@ -94,9 +94,7 @@ function buildContext(
   summary = "",
 ): string {
   const state = useTabsStore.getState();
-  const sessions = terminalTabs(state.tabs);
-  const currentId = targetTerminalId(state);
-  const current = sessions.find((session) => session.id === currentId);
+  const current = findPane(state.tabs, targetPaneId(state));
   const lines = [
     `App: Sageport v${__APP_VERSION__}, a desktop SSH client.`,
     `UI language: ${detectLocale()}.`,

--- a/src/features/ai/tools.test.ts
+++ b/src/features/ai/tools.test.ts
@@ -154,7 +154,9 @@ describe("reusableHostSession", () => {
     stale.hostId = "same-host";
     live.hostId = "same-host";
 
-    expect(reusableHostSession([tabOf(stale), tabOf(live)], "same-host")).toBe(live);
+    expect(reusableHostSession([tabOf(stale), tabOf(live)], "same-host")).toBe(
+      live,
+    );
   });
 
   it("returns a closed matching tab so it can be reconnected in place", () => {

--- a/src/features/ai/tools.test.ts
+++ b/src/features/ai/tools.test.ts
@@ -15,7 +15,7 @@ vi.mock("@/lib/ipc", () => ({
   },
 }));
 
-import type { TerminalTab } from "@/workbench/tabs";
+import type { TerminalPane, TerminalTab } from "@/workbench/tabs";
 import { useTabsStore } from "@/workbench/tabs";
 import {
   defaultTerminalOption,
@@ -28,10 +28,9 @@ import {
 function terminal(
   id: string,
   title: string,
-  status: TerminalTab["status"] = "connected",
-): TerminalTab {
+  status: TerminalPane["status"] = "connected",
+): TerminalPane {
   return {
-    kind: "terminal",
     id,
     target: "ssh",
     hostId: `host-${id}`,
@@ -41,11 +40,21 @@ function terminal(
   };
 }
 
+function tabOf(pane: TerminalPane): TerminalTab {
+  return {
+    kind: "terminal",
+    id: pane.id,
+    panes: [pane],
+    layout: { type: "leaf", paneId: pane.id },
+    activePaneId: pane.id,
+  };
+}
+
 beforeEach(() => {
   useTabsStore.setState({
     tabs: [],
     activeId: null,
-    lastTerminalId: null,
+    lastPaneId: null,
     pendingCloseId: null,
   });
 });
@@ -58,9 +67,9 @@ describe("defaultTerminalOption", () => {
     const current = terminal("current-id", "DMIT CORONA");
     const other = terminal("other-id", "10.10.30.56");
     useTabsStore.setState({
-      tabs: [other, current],
+      tabs: [tabOf(other), tabOf(current)],
       activeId: current.id,
-      lastTerminalId: current.id,
+      lastPaneId: current.id,
     });
 
     expect(
@@ -72,9 +81,9 @@ describe("defaultTerminalOption", () => {
     const current = terminal("current-id", "DMIT CORONA");
     const other = terminal("other-id", "10.10.30.56");
     useTabsStore.setState({
-      tabs: [current, other],
+      tabs: [tabOf(current), tabOf(other)],
       activeId: current.id,
-      lastTerminalId: current.id,
+      lastPaneId: current.id,
     });
 
     expect(
@@ -86,9 +95,9 @@ describe("defaultTerminalOption", () => {
     const current = terminal("current-id", "DMIT CORONA");
     const other = terminal("other-id", "10.10.30.56");
     useTabsStore.setState({
-      tabs: [current, other],
+      tabs: [tabOf(current), tabOf(other)],
       activeId: current.id,
-      lastTerminalId: current.id,
+      lastPaneId: current.id,
     });
 
     expect(
@@ -102,9 +111,9 @@ describe("defaultTerminalOption", () => {
   it("does not override an explicitly named host that is not open yet", () => {
     const current = terminal("current-id", "DMIT CORONA");
     useTabsStore.setState({
-      tabs: [current],
+      tabs: [tabOf(current)],
       activeId: current.id,
-      lastTerminalId: current.id,
+      lastPaneId: current.id,
     });
 
     expect(
@@ -121,9 +130,9 @@ describe("defaultTerminalOption", () => {
   it("does not swallow non-terminal choices or disconnected targets", () => {
     const current = terminal("current-id", "DMIT CORONA", "closed");
     useTabsStore.setState({
-      tabs: [current],
+      tabs: [tabOf(current)],
       activeId: current.id,
-      lastTerminalId: current.id,
+      lastPaneId: current.id,
     });
 
     expect(
@@ -145,14 +154,14 @@ describe("reusableHostSession", () => {
     stale.hostId = "same-host";
     live.hostId = "same-host";
 
-    expect(reusableHostSession([stale, live], "same-host")).toBe(live);
+    expect(reusableHostSession([tabOf(stale), tabOf(live)], "same-host")).toBe(live);
   });
 
   it("returns a closed matching tab so it can be reconnected in place", () => {
     const stale = terminal("stale", "Host", "closed");
     stale.hostId = "same-host";
 
-    expect(reusableHostSession([stale], "same-host")).toBe(stale);
+    expect(reusableHostSession([tabOf(stale)], "same-host")).toBe(stale);
   });
 });
 

--- a/src/features/ai/tools/ask.ts
+++ b/src/features/ai/tools/ask.ts
@@ -1,10 +1,11 @@
 import { MessageCircleQuestion } from "lucide-react";
 
 import {
-  targetTerminalId,
-  terminalTabs,
+  findPane,
+  targetPaneId,
+  terminalPanes,
   useTabsStore,
-  type TerminalTab,
+  type TerminalPane,
 } from "@/workbench/tabs";
 import type { AiTool, PreparedCall } from "./types";
 
@@ -39,16 +40,15 @@ function comparableText(value: string): string {
     .trim();
 }
 
-function resolveCurrentTab(): TerminalTab | null {
+function resolveCurrentPane(): TerminalPane | null {
   const state = useTabsStore.getState();
-  const id = targetTerminalId(state);
-  return terminalTabs(state.tabs).find((s) => s.id === id) ?? null;
+  return findPane(state.tabs, targetPaneId(state)) ?? null;
 }
 
 export function defaultTerminalOption(
   args: Record<string, unknown>,
   userPrompt: string,
-): { option: string; tab: TerminalTab } | null {
+): { option: string; tab: TerminalPane } | null {
   const question = askUserQuestion(args);
   const options = askUserOptions(args);
   if (!question || options.length < 2 || !TARGET_QUESTION_RE.test(question)) {
@@ -56,14 +56,14 @@ export function defaultTerminalOption(
   }
 
   const state = useTabsStore.getState();
-  const current = resolveCurrentTab();
+  const current = resolveCurrentPane();
   if (!current || current.status !== "connected") return null;
 
   const prompt = comparableText(userPrompt);
   if (MULTI_TARGET_RE.test(prompt)) return null;
 
-  const otherTargets = terminalTabs(state.tabs).filter(
-    (tab) => tab.id !== current.id,
+  const otherTargets = terminalPanes(state.tabs).filter(
+    (pane) => pane.id !== current.id,
   );
   if (
     otherTargets.some((tab) => {
@@ -104,7 +104,7 @@ export function defaultTerminalOption(
 
 export function automaticTerminalSelectionResult(
   option: string,
-  tab: TerminalTab,
+  tab: TerminalPane,
 ): string {
   return `The app automatically selected the current terminal: ${option} (title: "${tab.title}", sessionId: ${tab.id}). Continue without asking the user to choose a server.`;
 }

--- a/src/features/ai/tools/behavior.test.ts
+++ b/src/features/ai/tools/behavior.test.ts
@@ -31,19 +31,25 @@ vi.mock("@/lib/ipc", () => ({
 }));
 
 import { queryClient } from "@/lib/query";
-import type { TerminalTab } from "@/workbench/tabs";
+import type { TerminalPane, TerminalTab } from "@/workbench/tabs";
 import { useTabsStore } from "@/workbench/tabs";
 import { getTool } from "./registry";
 
 function terminal(id: string): TerminalTab {
-  return {
-    kind: "terminal",
+  const pane: TerminalPane = {
     id,
     target: "ssh",
     hostId: `host-${id}`,
     title: id,
     status: "connected",
     attempt: 0,
+  };
+  return {
+    kind: "terminal",
+    id,
+    panes: [pane],
+    layout: { type: "leaf", paneId: id },
+    activePaneId: id,
   };
 }
 
@@ -52,7 +58,7 @@ beforeEach(() => {
   useTabsStore.setState({
     tabs: [],
     activeId: null,
-    lastTerminalId: null,
+    lastPaneId: null,
     pendingCloseId: null,
   });
 });
@@ -63,7 +69,7 @@ describe("run_snippet prepare", () => {
     useTabsStore.setState({
       tabs: [current],
       activeId: current.id,
-      lastTerminalId: current.id,
+      lastPaneId: current.id,
     });
   });
 
@@ -107,7 +113,7 @@ describe("SFTP target preparation", () => {
     useTabsStore.setState({
       tabs: [current],
       activeId: current.id,
-      lastTerminalId: current.id,
+      lastPaneId: current.id,
     });
 
     const prepared = await getTool("write_file")!.prepare!(

--- a/src/features/ai/tools/files.ts
+++ b/src/features/ai/tools/files.ts
@@ -15,7 +15,7 @@ import { ipc } from "@/lib/ipc";
 import { errorMessage } from "@/lib/toast";
 import type { SftpStatusKind } from "@/types/models";
 import type { FsEndpoint, TransferEvent } from "@/types/models";
-import { resolveTerminalTab, sleep } from "./terminal";
+import { resolveTerminalPane, sleep } from "./terminal";
 import {
   bool,
   optionalStr,
@@ -62,7 +62,7 @@ async function resolveSftpConnection(
   }
   let targetHostId = hostId;
   if (!targetHostId) {
-    targetHostId = resolveTerminalTab()?.hostId || undefined;
+    targetHostId = resolveTerminalPane()?.hostId || undefined;
     if (!targetHostId) {
       return {
         error:
@@ -149,7 +149,7 @@ async function withConn(
 function prepareSftpTarget(args: Record<string, unknown>): PreparedCall {
   const requested = optionalStr(args, "hostId");
   if (requested) return { args: { ...args, hostId: requested } };
-  const hostId = resolveTerminalTab()?.hostId || undefined;
+  const hostId = resolveTerminalPane()?.hostId || undefined;
   if (!hostId) {
     return {
       args,

--- a/src/features/ai/tools/hosts.ts
+++ b/src/features/ai/tools/hosts.ts
@@ -19,10 +19,12 @@ import type {
   HostInput,
 } from "@/types/models";
 import {
-  terminalTabs,
+  findPane,
+  terminalPanes,
   useTabsStore,
+  type EditorTab,
+  type TerminalPane,
   type TerminalStatus,
-  type TerminalTab,
 } from "@/workbench/tabs";
 import { invalidateHosts } from "./cache";
 import { sleep } from "./terminal";
@@ -40,9 +42,9 @@ import {
 } from "./types";
 
 export function reusableHostSession(
-  tabs: Parameters<typeof terminalTabs>[0],
+  tabs: readonly EditorTab[],
   hostId: string,
-): TerminalTab | undefined {
+): TerminalPane | undefined {
   const priority: Record<TerminalStatus, number> = {
     connected: 0,
     connecting: 1,
@@ -50,8 +52,8 @@ export function reusableHostSession(
     closed: 3,
     error: 4,
   };
-  return terminalTabs(tabs)
-    .filter((tab) => tab.hostId === hostId)
+  return terminalPanes(tabs)
+    .filter((pane) => pane.hostId === hostId)
     .sort((a, b) => priority[a.status] - priority[b.status])[0];
 }
 
@@ -62,13 +64,11 @@ async function waitForConnection(
 ): Promise<TerminalStatus> {
   const start = Date.now();
   while (Date.now() - start < timeoutMs) {
-    const tab = terminalTabs(useTabsStore.getState().tabs).find(
-      (t) => t.id === id,
-    );
-    if (!tab) return "closed";
-    if (isCancelled()) return tab.status;
-    if (tab.status !== "connecting" && tab.status !== "idle") {
-      return tab.status;
+    const pane = findPane(useTabsStore.getState().tabs, id);
+    if (!pane) return "closed";
+    if (isCancelled()) return pane.status;
+    if (pane.status !== "connecting" && pane.status !== "idle") {
+      return pane.status;
     }
     await sleep(250);
   }
@@ -169,10 +169,8 @@ async function connectHost(
       `Still connecting to "${host.label}" (sessionId: ${id}). The user may need to answer a prompt in the terminal tab (host key trust, password). Check again later with list_terminal_sessions or read_terminal_output.`,
     );
   }
-  const tab = terminalTabs(useTabsStore.getState().tabs).find(
-    (t) => t.id === id,
-  );
-  const detail = tab?.error ? `: ${tab.error}` : ".";
+  const pane = findPane(useTabsStore.getState().tabs, id);
+  const detail = pane?.error ? `: ${pane.error}` : ".";
   return toolFailure(
     `Error: connection to "${host.label}" ${
       status === "error" ? "failed" : "was closed"

--- a/src/features/ai/tools/index.ts
+++ b/src/features/ai/tools/index.ts
@@ -9,7 +9,7 @@ export {
   executeTerminalCommand,
   newOutput,
   noTerminalSessionError,
-  resolveTerminalTab,
+  resolveTerminalPane,
   sessionNotConnectedError,
   terminalReadLineLimit,
 } from "./terminal";

--- a/src/features/ai/tools/monitor.ts
+++ b/src/features/ai/tools/monitor.ts
@@ -9,7 +9,7 @@ import {
 import type { HostStats } from "@/types/models";
 import {
   noTerminalSessionError,
-  resolveTerminalTab,
+  resolveTerminalPane,
   sessionNotConnectedError,
   sleep,
 } from "./terminal";
@@ -72,7 +72,7 @@ async function getHostStats(
 ): Promise<ToolExecutionResult> {
   const requested =
     typeof args.sessionId === "string" ? args.sessionId : undefined;
-  const tab = resolveTerminalTab(requested);
+  const tab = resolveTerminalPane(requested);
   if (!tab) return toolFailure(noTerminalSessionError(requested));
   if (tab.status !== "connected") {
     return toolFailure(sessionNotConnectedError(tab));

--- a/src/features/ai/tools/terminal.ts
+++ b/src/features/ai/tools/terminal.ts
@@ -3,11 +3,13 @@ import { Eye, History, ListTree, Terminal as TerminalIcon } from "lucide-react";
 import { isShellPromptLine } from "@/features/terminal/autocomplete/engine";
 import { getSession, readTerminalContext } from "@/features/terminal/sessions";
 import { ipc } from "@/lib/ipc";
+import { layoutPaneIds } from "@/workbench/pane-layout";
 import {
-  targetTerminalId,
+  targetPaneId,
+  terminalPanes,
   terminalTabs,
   useTabsStore,
-  type TerminalTab,
+  type TerminalPane,
 } from "@/workbench/tabs";
 import {
   num,
@@ -27,13 +29,13 @@ export function sleep(ms: number): Promise<void> {
   return new Promise<void>((resolve) => setTimeout(resolve, ms));
 }
 
-export function resolveTerminalTab(requested?: string): TerminalTab | null {
+export function resolveTerminalPane(requested?: string): TerminalPane | null {
   const state = useTabsStore.getState();
-  const sessions = terminalTabs(state.tabs);
+  const sessions = terminalPanes(state.tabs);
   if (requested) {
     return sessions.find((s) => s.id === requested) ?? null;
   }
-  const id = targetTerminalId(state);
+  const id = targetPaneId(state);
   return sessions.find((s) => s.id === id) ?? null;
 }
 
@@ -43,8 +45,8 @@ export function noTerminalSessionError(requested?: string): string {
     : "Error: no active terminal session. Call list_terminal_sessions to pick one, or connect_host to open one.";
 }
 
-export function sessionNotConnectedError(tab: TerminalTab): string {
-  return `Error: terminal session "${tab.title}" (${tab.id}) is not connected (status: ${tab.status}). Reconnect it with connect_host or pick a connected session from list_terminal_sessions.`;
+export function sessionNotConnectedError(pane: TerminalPane): string {
+  return `Error: terminal session "${pane.title}" (${pane.id}) is not connected (status: ${pane.status}). Reconnect it with connect_host or pick a connected session from list_terminal_sessions.`;
 }
 
 export function prepareTerminalTarget(
@@ -52,17 +54,17 @@ export function prepareTerminalTarget(
 ): PreparedCall {
   const requested =
     typeof args.sessionId === "string" ? args.sessionId : undefined;
-  const tab = resolveTerminalTab(requested);
-  if (!tab) {
+  const pane = resolveTerminalPane(requested);
+  if (!pane) {
     return { args, preflightError: noTerminalSessionError(requested) };
   }
-  if (tab.status !== "connected") {
+  if (pane.status !== "connected") {
     return {
-      args: { ...args, sessionId: tab.id },
-      preflightError: sessionNotConnectedError(tab),
+      args: { ...args, sessionId: pane.id },
+      preflightError: sessionNotConnectedError(pane),
     };
   }
-  return { args: { ...args, sessionId: tab.id } };
+  return { args: { ...args, sessionId: pane.id } };
 }
 
 export function terminalReadLineLimit(value: unknown): number {
@@ -133,22 +135,35 @@ async function waitForSettledOutput(
 
 function listSessions(): ToolExecutionResult {
   const state = useTabsStore.getState();
-  const sessions = terminalTabs(state.tabs);
-  if (sessions.length === 0) {
+  const tabs = terminalTabs(state.tabs);
+  if (tabs.length === 0) {
     return toolSuccess(
       "No terminal sessions are open right now. Use connect_host to open one.",
     );
   }
-  const focusedId = targetTerminalId(state);
+  const focusedId = targetPaneId(state);
   return toolSuccess(
     JSON.stringify(
-      sessions.map((s) => ({
-        id: s.id,
-        title: s.title,
-        hostId: s.hostId || undefined,
-        status: s.status,
-        current: s.id === focusedId,
-      })),
+      tabs.flatMap((tab) => {
+        const ordered = layoutPaneIds(tab.layout);
+        return ordered.flatMap((paneId, index) => {
+          const pane = tab.panes.find((item) => item.id === paneId);
+          if (!pane) return [];
+          return [
+            {
+              id: pane.id,
+              title: pane.title,
+              hostId: pane.hostId || undefined,
+              status: pane.status,
+              current: pane.id === focusedId,
+              pane:
+                ordered.length > 1
+                  ? `${index + 1}/${ordered.length}`
+                  : undefined,
+            },
+          ];
+        });
+      }),
     ),
   );
 }
@@ -156,11 +171,11 @@ function listSessions(): ToolExecutionResult {
 function readOutput(args: Record<string, unknown>): ToolExecutionResult {
   const requested =
     typeof args.sessionId === "string" ? args.sessionId : undefined;
-  const tab = resolveTerminalTab(requested);
-  if (!tab) return toolFailure(noTerminalSessionError(requested));
+  const pane = resolveTerminalPane(requested);
+  if (!pane) return toolFailure(noTerminalSessionError(requested));
 
   const lines = terminalReadLineLimit(args.lines);
-  const text = readTerminalContext(tab.id, lines);
+  const text = readTerminalContext(pane.id, lines);
   return toolSuccess(text || "(the terminal has no output yet)");
 }
 
@@ -173,10 +188,10 @@ export async function executeTerminalCommand(
 
   const requested =
     typeof args.sessionId === "string" ? args.sessionId : undefined;
-  const tab = resolveTerminalTab(requested);
-  if (!tab) return toolFailure(noTerminalSessionError(requested));
-  if (tab.status !== "connected") {
-    return toolFailure(sessionNotConnectedError(tab));
+  const pane = resolveTerminalPane(requested);
+  if (!pane) return toolFailure(noTerminalSessionError(requested));
+  if (pane.status !== "connected") {
+    return toolFailure(sessionNotConnectedError(pane));
   }
 
   const timeoutMs = Math.min(
@@ -186,13 +201,13 @@ export async function executeTerminalCommand(
     30_000,
   );
 
-  const session = getSession(tab.id);
+  const session = getSession(pane.id);
   if (!session) return toolFailure(noTerminalSessionError(requested));
-  const before = readTerminalContext(tab.id, MAX_TERMINAL_READ_LINES) ?? "";
+  const before = readTerminalContext(pane.id, MAX_TERMINAL_READ_LINES) ?? "";
   const promptBefore = before.split("\n").at(-1) ?? "";
   session.sendCommand(command);
   const after = await waitForSettledOutput(
-    tab.id,
+    pane.id,
     timeoutMs,
     context.isCancelled,
     isShellPromptLine(promptBefore),
@@ -231,7 +246,7 @@ export const terminalTools: AiTool[] = [
     spec: {
       name: "list_terminal_sessions",
       description:
-        "List open terminal ids, titles, statuses, and the current marker. Do not call merely to reconfirm the Current terminal in app context.",
+        "List open terminal ids, titles, statuses, and the current marker. Split panes are separate sessions; a pane field like 1/2 marks panes sharing one tab. Do not call merely to reconfirm the Current terminal in app context.",
       parameters: {
         type: "object",
         properties: {},

--- a/src/features/hosts/HostsView.tsx
+++ b/src/features/hosts/HostsView.tsx
@@ -48,7 +48,7 @@ import {
 } from "@/workbench/PanelHeader";
 import { SideBarView } from "@/workbench/SideBarView";
 import { SideBarFilter } from "@/workbench/SideBarFilter";
-import { terminalTabs, useTabsStore } from "@/workbench/tabs";
+import { terminalPanes, useTabsStore } from "@/workbench/tabs";
 import { useSftpStore } from "@/features/sftp/store";
 import { useMonitorStore } from "@/features/terminal/monitor";
 import {
@@ -628,7 +628,7 @@ function HostRow({
   const { t } = useI18n();
   const openTerminal = useTabsStore((s) => s.openTerminal);
   const tabs = useTabsStore((s) => s.tabs);
-  const hostSessions = terminalTabs(tabs).filter((x) => x.hostId === host.id);
+  const hostSessions = terminalPanes(tabs).filter((x) => x.hostId === host.id);
   const connected = hostSessions.some((x) => x.status === "connected");
   const detectedOs = useMonitorStore((s) =>
     hostSessions

--- a/src/features/monitor/MonitorView.tsx
+++ b/src/features/monitor/MonitorView.tsx
@@ -28,7 +28,11 @@ import { PanelContent } from "@/workbench/PanelHeader";
 import { SideBarView } from "@/workbench/SideBarView";
 import { SideBarFilter } from "@/workbench/SideBarFilter";
 import { STATUS_DOT_CLASS } from "@/workbench/tab-styles";
-import { terminalPanes, useTabsStore, type TerminalPane } from "@/workbench/tabs";
+import {
+  terminalPanes,
+  useTabsStore,
+  type TerminalPane,
+} from "@/workbench/tabs";
 
 export function MonitorView() {
   const { t } = useI18n();

--- a/src/features/monitor/MonitorView.tsx
+++ b/src/features/monitor/MonitorView.tsx
@@ -28,7 +28,7 @@ import { PanelContent } from "@/workbench/PanelHeader";
 import { SideBarView } from "@/workbench/SideBarView";
 import { SideBarFilter } from "@/workbench/SideBarFilter";
 import { STATUS_DOT_CLASS } from "@/workbench/tab-styles";
-import { terminalTabs, useTabsStore, type TerminalTab } from "@/workbench/tabs";
+import { terminalPanes, useTabsStore, type TerminalPane } from "@/workbench/tabs";
 
 export function MonitorView() {
   const { t } = useI18n();
@@ -42,7 +42,7 @@ export function MonitorView() {
   }, []);
 
   const groups = groupByHost(
-    terminalTabs(tabs).filter((tab) => tab.target !== "local"),
+    terminalPanes(tabs).filter((pane) => pane.target !== "local"),
   );
   const hostById = new Map(hosts.map((host) => [host.id, host]));
   const q = query.trim().toLowerCase();
@@ -99,7 +99,7 @@ export function MonitorView() {
   );
 }
 
-function hostKey(tab: TerminalTab): string {
+function hostKey(tab: TerminalPane): string {
   if (tab.target === "ssh") return `host:${tab.hostId}`;
   if (tab.adhoc)
     return JSON.stringify([
@@ -111,9 +111,9 @@ function hostKey(tab: TerminalTab): string {
   return tab.id;
 }
 
-function groupByHost(sessions: TerminalTab[]) {
-  const groups: { key: string; sessions: TerminalTab[] }[] = [];
-  const byKey = new Map<string, TerminalTab[]>();
+function groupByHost(sessions: TerminalPane[]) {
+  const groups: { key: string; sessions: TerminalPane[] }[] = [];
+  const byKey = new Map<string, TerminalPane[]>();
   for (const session of sessions) {
     const key = hostKey(session);
     const group = byKey.get(key);
@@ -128,7 +128,7 @@ function groupByHost(sessions: TerminalTab[]) {
   return groups;
 }
 
-function hostAddress(session: TerminalTab, host?: Host): string | null {
+function hostAddress(session: TerminalPane, host?: Host): string | null {
   if (session.adhoc) {
     const { username, host: addr, port } = session.adhoc;
     return `${username}@${addr}${port === 22 ? "" : `:${port}`}`;
@@ -151,12 +151,15 @@ function HostCard({
   sessions,
   host,
 }: {
-  sessions: TerminalTab[];
+  sessions: TerminalPane[];
   host?: Host;
 }) {
   const { t } = useI18n();
   const setActive = useTabsStore((s) => s.setActive);
-  const activeId = useTabsStore((s) => s.activeId);
+  const activeId = useTabsStore((s) => {
+    const active = s.tabs.find((tab) => tab.id === s.activeId);
+    return active?.kind === "terminal" ? active.activePaneId : null;
+  });
   const connectedSessions = sessions.filter(
     (session) => session.status === "connected",
   );

--- a/src/features/terminal/TerminalEditor.tsx
+++ b/src/features/terminal/TerminalEditor.tsx
@@ -1,4 +1,11 @@
-import { memo, useEffect, useLayoutEffect, useRef, useState } from "react";
+import {
+  Fragment,
+  memo,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
 import type { ISearchOptions } from "@xterm/addon-search";
 import {
   ArrowDown,
@@ -19,16 +26,24 @@ import {
   FindCount,
   FindInput,
   FindToggleButton,
+  ResizeHandle,
 } from "@/components/ui";
 import { useI18n } from "@/i18n";
 import { isValidRegex } from "@/lib/utils";
 import { useTheme } from "@/themes";
 import { monoFontFamily, useFontStore } from "@/workbench/font";
-import { useTabsStore, type TerminalTab } from "@/workbench/tabs";
+import type { PaneLayout } from "@/workbench/pane-layout";
+import {
+  useTabsStore,
+  type TerminalPane,
+  type TerminalTab,
+} from "@/workbench/tabs";
 import { terminalFontSize, useZoomStore } from "@/workbench/zoom";
 import { useTerminalSearch } from "./search";
 import { focusTerminal, getSession } from "./sessions";
 import { TerminalView } from "./TerminalView";
+
+const MIN_PANE_PX = 90;
 
 export const TerminalEditor = memo(function TerminalEditor({
   tab,
@@ -37,29 +52,138 @@ export const TerminalEditor = memo(function TerminalEditor({
   tab: TerminalTab;
   active: boolean;
 }) {
-  const reconnect = useTabsStore((s) => s.reconnectTerminal);
-  const searchOpen = useTerminalSearch((s) => s.openFor === tab.id);
-
   useLayoutEffect(() => {
-    if (active) getSession(tab.id)?.refit();
-  }, [active, tab.id]);
+    if (!active) return;
+    for (const pane of tab.panes) getSession(pane.id)?.refit();
+  }, [active, tab.panes]);
 
   return (
-    <div className="relative h-full w-full bg-terminal-background">
-      <TerminalView
-        sessionId={tab.id}
-        target={tab.target}
-        hostId={tab.hostId}
-        adhoc={tab.adhoc}
-        attempt={tab.attempt}
-        active={active}
-      />
-      <StickyCommand key={tab.attempt} sessionId={tab.id} />
-      {searchOpen && active && <SearchBar sessionId={tab.id} />}
-      <StatusOverlay tab={tab} onReconnect={() => reconnect(tab.id)} />
+    <div className="h-full w-full bg-terminal-background">
+      <LayoutNode node={tab.layout} tab={tab} active={active} />
     </div>
   );
 });
+
+function LayoutNode({
+  node,
+  tab,
+  active,
+}: {
+  node: PaneLayout;
+  tab: TerminalTab;
+  active: boolean;
+}) {
+  if (node.type === "leaf") {
+    const pane = tab.panes.find((item) => item.id === node.paneId);
+    if (!pane) return null;
+    return <PaneView pane={pane} tab={tab} active={active} />;
+  }
+  return <SplitView node={node} tab={tab} active={active} />;
+}
+
+function SplitView({
+  node,
+  tab,
+  active,
+}: {
+  node: Extract<PaneLayout, { type: "split" }>;
+  tab: TerminalTab;
+  active: boolean;
+}) {
+  const resizePanes = useTabsStore((s) => s.resizePanes);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const childRefs = useRef<(HTMLDivElement | null)[]>([]);
+  const horizontal = node.direction === "row";
+
+  const measure = (el: HTMLDivElement | null) =>
+    el ? (horizontal ? el.offsetWidth : el.offsetHeight) : 0;
+
+  const pairPx = (index: number) =>
+    measure(childRefs.current[index]) + measure(childRefs.current[index + 1]);
+
+  const applyResize = (index: number, px: number) => {
+    const container = containerRef.current;
+    const total = measure(container);
+    if (!container || total <= 0) return;
+    const pair = node.sizes[index] + node.sizes[index + 1];
+    const clamped = Math.min(
+      Math.max(px, MIN_PANE_PX),
+      Math.max(pairPx(index) - MIN_PANE_PX, MIN_PANE_PX),
+    );
+    const sizes = [...node.sizes];
+    sizes[index] = Math.min(clamped / total, pair);
+    sizes[index + 1] = pair - sizes[index];
+    resizePanes(tab.id, node.id, sizes);
+  };
+
+  return (
+    <div
+      ref={containerRef}
+      className={horizontal ? "flex h-full w-full" : "flex h-full w-full flex-col"}
+    >
+      {node.children.map((child, i) => (
+        <Fragment key={child.type === "leaf" ? child.paneId : child.id}>
+          {i > 0 && (
+            <ResizeHandle
+              axis={horizontal ? "x" : "y"}
+              getSize={() => measure(childRefs.current[i - 1])}
+              onResize={(px) => applyResize(i - 1, px)}
+              limits={() => ({
+                min: MIN_PANE_PX,
+                max: Math.max(pairPx(i - 1) - MIN_PANE_PX, MIN_PANE_PX),
+              })}
+            />
+          )}
+          <div
+            ref={(el) => {
+              childRefs.current[i] = el;
+            }}
+            className="min-h-0 min-w-0"
+            style={{ flexGrow: node.sizes[i], flexShrink: 1, flexBasis: 0 }}
+          >
+            <LayoutNode node={child} tab={tab} active={active} />
+          </div>
+        </Fragment>
+      ))}
+    </div>
+  );
+}
+
+function PaneView({
+  pane,
+  tab,
+  active,
+}: {
+  pane: TerminalPane;
+  tab: TerminalTab;
+  active: boolean;
+}) {
+  const reconnect = useTabsStore((s) => s.reconnectTerminal);
+  const focusPane = useTabsStore((s) => s.focusPane);
+  const searchOpen = useTerminalSearch((s) => s.openFor === pane.id);
+  const paneActive = active && tab.activePaneId === pane.id;
+
+  return (
+    <div
+      className="relative h-full w-full bg-terminal-background"
+      onFocusCapture={() => {
+        if (tab.activePaneId !== pane.id) focusPane(pane.id);
+      }}
+    >
+      <TerminalView
+        sessionId={pane.id}
+        target={pane.target}
+        hostId={pane.hostId}
+        adhoc={pane.adhoc}
+        attempt={pane.attempt}
+        active={paneActive}
+      />
+      <StickyCommand key={pane.attempt} sessionId={pane.id} />
+      {searchOpen && active && <SearchBar sessionId={pane.id} />}
+      <StatusOverlay pane={pane} onReconnect={() => reconnect(pane.id)} />
+    </div>
+  );
+}
 
 function StickyCommand({ sessionId }: { sessionId: string }) {
   const [sticky, setSticky] = useState<{ text: string; line: number }>();
@@ -271,27 +395,27 @@ function SearchBar({ sessionId }: { sessionId: string }) {
 }
 
 function StatusOverlay({
-  tab,
+  pane,
   onReconnect,
 }: {
-  tab: TerminalTab;
+  pane: TerminalPane;
   onReconnect: () => void;
 }) {
   const { t } = useI18n();
 
-  if (tab.status === "connecting") {
+  if (pane.status === "connecting") {
     return (
       <Shell>
         <Loader2 className="size-7 animate-spin text-link" />
         <p className="text-sm font-medium text-foreground">
-          {t("terminal.connecting", { host: tab.title })}
+          {t("terminal.connecting", { host: pane.title })}
         </p>
       </Shell>
     );
   }
 
-  if (tab.status === "error") {
-    const cancelled = tab.errorCode === "cancelled";
+  if (pane.status === "error") {
+    const cancelled = pane.errorCode === "cancelled";
     return (
       <Shell>
         <span className="flex size-12 items-center justify-center rounded-full bg-danger/10 text-danger">
@@ -302,9 +426,9 @@ function StatusOverlay({
             cancelled ? "terminal.connectCancelled" : "terminal.connectFailed",
           )}
         </p>
-        {tab.error && (
+        {pane.error && (
           <p className="max-w-md select-text break-words text-center font-mono text-xs leading-relaxed text-danger">
-            {tab.error}
+            {pane.error}
           </p>
         )}
         <Button size="sm" variant="outline" onClick={onReconnect}>
@@ -314,7 +438,7 @@ function StatusOverlay({
     );
   }
 
-  if (tab.status === "closed") {
+  if (pane.status === "closed") {
     return (
       <Shell>
         <span className="flex size-12 items-center justify-center rounded-full bg-muted text-muted-foreground">

--- a/src/features/terminal/TerminalEditor.tsx
+++ b/src/features/terminal/TerminalEditor.tsx
@@ -1,10 +1,12 @@
 import {
   Fragment,
   memo,
+  useCallback,
   useEffect,
   useLayoutEffect,
   useRef,
   useState,
+  useSyncExternalStore,
 } from "react";
 import { readText, writeText } from "@tauri-apps/plugin-clipboard-manager";
 import type { ISearchOptions } from "@xterm/addon-search";
@@ -152,7 +154,9 @@ function SplitView({
   return (
     <div
       ref={containerRef}
-      className={horizontal ? "flex h-full w-full" : "flex h-full w-full flex-col"}
+      className={
+        horizontal ? "flex h-full w-full" : "flex h-full w-full flex-col"
+      }
     >
       {node.children.map((child, i) => (
         <Fragment key={child.type === "leaf" ? child.paneId : child.id}>
@@ -198,18 +202,17 @@ function PaneView({
   const closePane = useTabsStore((s) => s.closePane);
   const searchOpen = useTerminalSearch((s) => s.openFor === pane.id);
   const paneActive = active && tab.activePaneId === pane.id;
-  const [hasSelection, setHasSelection] = useState(
-    () => getSession(pane.id)?.term.hasSelection() ?? false,
+  const term = getSession(pane.id)?.term;
+  const hasSelection = useSyncExternalStore(
+    useCallback(
+      (onSelectionChange) => {
+        const sub = term?.onSelectionChange(onSelectionChange);
+        return () => sub?.dispose();
+      },
+      [term],
+    ),
+    () => term?.hasSelection() ?? false,
   );
-
-  useEffect(() => {
-    const term = getSession(pane.id)?.term;
-    if (!term) return;
-    const sub = term.onSelectionChange(() =>
-      setHasSelection(term.hasSelection()),
-    );
-    return () => sub.dispose();
-  }, [pane.id]);
 
   const runAndRefocus = (action: () => void) => () => {
     action();
@@ -253,7 +256,9 @@ function PaneView({
         <ContextMenuItem onSelect={runAndRefocus(() => selectPaneAll(pane.id))}>
           <SquareDashedMousePointer /> {t("terminal.menu.selectAll")}
         </ContextMenuItem>
-        <ContextMenuItem onSelect={runAndRefocus(() => clearPaneBuffer(pane.id))}>
+        <ContextMenuItem
+          onSelect={runAndRefocus(() => clearPaneBuffer(pane.id))}
+        >
           <Eraser /> {t("terminal.menu.clear")}
         </ContextMenuItem>
         <ContextMenuSeparator />
@@ -262,7 +267,9 @@ function PaneView({
         >
           <SquareSplitHorizontal /> {t("commands.terminal.splitRight")}
         </ContextMenuItem>
-        <ContextMenuItem onSelect={runAndRefocus(() => splitPane(pane.id, "down"))}>
+        <ContextMenuItem
+          onSelect={runAndRefocus(() => splitPane(pane.id, "down"))}
+        >
           <SquareSplitVertical /> {t("commands.terminal.splitDown")}
         </ContextMenuItem>
         <ContextMenuSeparator />

--- a/src/features/terminal/TerminalEditor.tsx
+++ b/src/features/terminal/TerminalEditor.tsx
@@ -39,7 +39,6 @@ import {
   FindInput,
   FindToggleButton,
   ResizeHandle,
-  Tooltip,
 } from "@/components/ui";
 import { useI18n } from "@/i18n";
 import { isValidRegex } from "@/lib/utils";
@@ -78,34 +77,6 @@ function clearPaneBuffer(paneId: string) {
 }
 
 const MIN_PANE_PX = 90;
-
-export function TerminalTabActions({ paneId }: { paneId: string }) {
-  const { t } = useI18n();
-  const splitPane = useTabsStore((s) => s.splitPane);
-
-  return (
-    <>
-      <Tooltip content={t("commands.terminal.splitRight")}>
-        <button
-          type="button"
-          onClick={() => splitPane(paneId, "right")}
-          className="ml-1 flex size-[var(--toolbar-control-size)] shrink-0 items-center justify-center self-center rounded-lg text-muted-foreground outline-none transition-colors hover:bg-accent hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/35"
-        >
-          <SquareSplitHorizontal className="size-4" />
-        </button>
-      </Tooltip>
-      <Tooltip content={t("commands.terminal.splitDown")}>
-        <button
-          type="button"
-          onClick={() => splitPane(paneId, "down")}
-          className="flex size-[var(--toolbar-control-size)] shrink-0 items-center justify-center self-center rounded-lg text-muted-foreground outline-none transition-colors hover:bg-accent hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/35"
-        >
-          <SquareSplitVertical className="size-4" />
-        </button>
-      </Tooltip>
-    </>
-  );
-}
 
 export const TerminalEditor = memo(function TerminalEditor({
   tab,

--- a/src/features/terminal/TerminalEditor.tsx
+++ b/src/features/terminal/TerminalEditor.tsx
@@ -6,27 +6,40 @@ import {
   useRef,
   useState,
 } from "react";
+import { readText, writeText } from "@tauri-apps/plugin-clipboard-manager";
 import type { ISearchOptions } from "@xterm/addon-search";
 import {
   ArrowDown,
   ArrowUp,
   CaseSensitive,
+  ClipboardPaste,
+  Copy,
+  Eraser,
   Loader2,
   PlugZap,
   Regex,
   ServerCrash,
+  SquareDashedMousePointer,
+  SquareSplitHorizontal,
+  SquareSplitVertical,
   WholeWord,
   X,
 } from "lucide-react";
 
 import {
   Button,
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuSeparator,
+  ContextMenuTrigger,
   FindActionButton,
   FindBar,
   FindCount,
   FindInput,
   FindToggleButton,
   ResizeHandle,
+  Tooltip,
 } from "@/components/ui";
 import { useI18n } from "@/i18n";
 import { isValidRegex } from "@/lib/utils";
@@ -43,7 +56,56 @@ import { useTerminalSearch } from "./search";
 import { focusTerminal, getSession } from "./sessions";
 import { TerminalView } from "./TerminalView";
 
+async function copyPaneSelection(paneId: string) {
+  const term = getSession(paneId)?.term;
+  if (!term?.hasSelection()) return;
+  await writeText(term.getSelection());
+}
+
+async function pastePaneClipboard(paneId: string) {
+  const session = getSession(paneId);
+  if (!session) return;
+  const text = await readText().catch(() => "");
+  if (text) session.term.paste(text);
+}
+
+function selectPaneAll(paneId: string) {
+  getSession(paneId)?.term.selectAll();
+}
+
+function clearPaneBuffer(paneId: string) {
+  getSession(paneId)?.term.clear();
+}
+
 const MIN_PANE_PX = 90;
+
+export function TerminalTabActions({ paneId }: { paneId: string }) {
+  const { t } = useI18n();
+  const splitPane = useTabsStore((s) => s.splitPane);
+
+  return (
+    <>
+      <Tooltip content={t("commands.terminal.splitRight")}>
+        <button
+          type="button"
+          onClick={() => splitPane(paneId, "right")}
+          className="ml-1 flex size-[var(--toolbar-control-size)] shrink-0 items-center justify-center self-center rounded-lg text-muted-foreground outline-none transition-colors hover:bg-accent hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/35"
+        >
+          <SquareSplitHorizontal className="size-4" />
+        </button>
+      </Tooltip>
+      <Tooltip content={t("commands.terminal.splitDown")}>
+        <button
+          type="button"
+          onClick={() => splitPane(paneId, "down")}
+          className="flex size-[var(--toolbar-control-size)] shrink-0 items-center justify-center self-center rounded-lg text-muted-foreground outline-none transition-colors hover:bg-accent hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/35"
+        >
+          <SquareSplitVertical className="size-4" />
+        </button>
+      </Tooltip>
+    </>
+  );
+}
 
 export const TerminalEditor = memo(function TerminalEditor({
   tab,
@@ -158,30 +220,91 @@ function PaneView({
   tab: TerminalTab;
   active: boolean;
 }) {
+  const { t } = useI18n();
   const reconnect = useTabsStore((s) => s.reconnectTerminal);
   const focusPane = useTabsStore((s) => s.focusPane);
+  const splitPane = useTabsStore((s) => s.splitPane);
+  const closePane = useTabsStore((s) => s.closePane);
   const searchOpen = useTerminalSearch((s) => s.openFor === pane.id);
   const paneActive = active && tab.activePaneId === pane.id;
+  const [hasSelection, setHasSelection] = useState(
+    () => getSession(pane.id)?.term.hasSelection() ?? false,
+  );
+
+  useEffect(() => {
+    const term = getSession(pane.id)?.term;
+    if (!term) return;
+    const sub = term.onSelectionChange(() =>
+      setHasSelection(term.hasSelection()),
+    );
+    return () => sub.dispose();
+  }, [pane.id]);
+
+  const runAndRefocus = (action: () => void) => () => {
+    action();
+    getSession(pane.id)?.focus();
+  };
 
   return (
-    <div
-      className="relative h-full w-full bg-terminal-background"
-      onFocusCapture={() => {
-        if (tab.activePaneId !== pane.id) focusPane(pane.id);
-      }}
-    >
-      <TerminalView
-        sessionId={pane.id}
-        target={pane.target}
-        hostId={pane.hostId}
-        adhoc={pane.adhoc}
-        attempt={pane.attempt}
-        active={paneActive}
-      />
-      <StickyCommand key={pane.attempt} sessionId={pane.id} />
-      {searchOpen && active && <SearchBar sessionId={pane.id} />}
-      <StatusOverlay pane={pane} onReconnect={() => reconnect(pane.id)} />
-    </div>
+    <ContextMenu>
+      <ContextMenuTrigger asChild>
+        <div
+          className="relative h-full w-full bg-terminal-background"
+          onFocusCapture={() => {
+            if (tab.activePaneId !== pane.id) focusPane(pane.id);
+          }}
+        >
+          <TerminalView
+            sessionId={pane.id}
+            target={pane.target}
+            hostId={pane.hostId}
+            adhoc={pane.adhoc}
+            attempt={pane.attempt}
+            active={paneActive}
+          />
+          <StickyCommand key={pane.attempt} sessionId={pane.id} />
+          {searchOpen && active && <SearchBar sessionId={pane.id} />}
+          <StatusOverlay pane={pane} onReconnect={() => reconnect(pane.id)} />
+        </div>
+      </ContextMenuTrigger>
+      <ContextMenuContent>
+        <ContextMenuItem
+          disabled={!hasSelection}
+          onSelect={runAndRefocus(() => void copyPaneSelection(pane.id))}
+        >
+          <Copy /> {t("common.copy")}
+        </ContextMenuItem>
+        <ContextMenuItem
+          onSelect={runAndRefocus(() => void pastePaneClipboard(pane.id))}
+        >
+          <ClipboardPaste /> {t("terminal.menu.paste")}
+        </ContextMenuItem>
+        <ContextMenuItem onSelect={runAndRefocus(() => selectPaneAll(pane.id))}>
+          <SquareDashedMousePointer /> {t("terminal.menu.selectAll")}
+        </ContextMenuItem>
+        <ContextMenuItem onSelect={runAndRefocus(() => clearPaneBuffer(pane.id))}>
+          <Eraser /> {t("terminal.menu.clear")}
+        </ContextMenuItem>
+        <ContextMenuSeparator />
+        <ContextMenuItem
+          onSelect={runAndRefocus(() => splitPane(pane.id, "right"))}
+        >
+          <SquareSplitHorizontal /> {t("commands.terminal.splitRight")}
+        </ContextMenuItem>
+        <ContextMenuItem onSelect={runAndRefocus(() => splitPane(pane.id, "down"))}>
+          <SquareSplitVertical /> {t("commands.terminal.splitDown")}
+        </ContextMenuItem>
+        <ContextMenuSeparator />
+        <ContextMenuItem destructive onSelect={() => closePane(pane.id)}>
+          <X />{" "}
+          {t(
+            tab.panes.length > 1
+              ? "terminal.menu.closePane"
+              : "terminal.menu.closeTerminal",
+          )}
+        </ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
   );
 }
 
@@ -224,8 +347,6 @@ function StickyCommand({ sessionId }: { sessionId: string }) {
         fontFamily: monoFontFamily(),
         fontSize: terminalFontSize(),
         lineHeight: 1.25,
-        paddingLeft: 20,
-        paddingRight: 20,
       }}
     >
       {sticky.text}

--- a/src/features/terminal/TerminalView.tsx
+++ b/src/features/terminal/TerminalView.tsx
@@ -3,7 +3,7 @@ import { useEffect, useRef } from "react";
 import { useI18n } from "@/i18n";
 import { useTheme } from "@/themes/useTheme";
 import {
-  terminalTabs,
+  terminalPanes,
   useTabsStore,
   type AdhocTarget,
   type TerminalTarget,
@@ -120,8 +120,8 @@ export function TerminalView({
       onUserInput: (data) => {
         autocomplete.handleData(data);
         if (useBroadcastStore.getState().enabled) {
-          const tabs = terminalTabs(useTabsStore.getState().tabs);
-          for (const other of broadcastTargets(tabs, sessionId)) {
+          const panes = terminalPanes(useTabsStore.getState().tabs);
+          for (const other of broadcastTargets(panes, sessionId)) {
             getSession(other.id)?.send(data);
           }
         }

--- a/src/features/terminal/broadcast.test.ts
+++ b/src/features/terminal/broadcast.test.ts
@@ -1,15 +1,14 @@
 import { describe, expect, it } from "vitest";
 
-import type { TerminalTab } from "@/workbench/tabs";
+import type { TerminalPane } from "@/workbench/tabs";
 import { broadcastTargets } from "./broadcast";
 
-function tab(
+function pane(
   id: string,
-  target: TerminalTab["target"],
-  status: TerminalTab["status"],
-): TerminalTab {
+  target: TerminalPane["target"],
+  status: TerminalPane["status"],
+): TerminalPane {
   return {
-    kind: "terminal",
     id,
     target,
     hostId: target === "ssh" ? `host-${id}` : "",
@@ -21,24 +20,24 @@ function tab(
 
 describe("broadcastTargets", () => {
   it("includes every other connected SSH and local terminal", () => {
-    const tabs = [
-      tab("source", "ssh", "connected"),
-      tab("local", "local", "connected"),
-      tab("adhoc", "ssh-adhoc", "connected"),
-      tab("offline", "ssh", "closed"),
+    const panes = [
+      pane("source", "ssh", "connected"),
+      pane("local", "local", "connected"),
+      pane("adhoc", "ssh-adhoc", "connected"),
+      pane("offline", "ssh", "closed"),
     ];
 
-    expect(broadcastTargets(tabs, "source").map((item) => item.id)).toEqual([
+    expect(broadcastTargets(panes, "source").map((item) => item.id)).toEqual([
       "local",
       "adhoc",
     ]);
   });
 
   it("does not broadcast input from a source that is not connected", () => {
-    const tabs = [
-      tab("source", "local", "connecting"),
-      tab("remote", "ssh", "connected"),
+    const panes = [
+      pane("source", "local", "connecting"),
+      pane("remote", "ssh", "connected"),
     ];
-    expect(broadcastTargets(tabs, "source")).toEqual([]);
+    expect(broadcastTargets(panes, "source")).toEqual([]);
   });
 });

--- a/src/features/terminal/broadcast.ts
+++ b/src/features/terminal/broadcast.ts
@@ -1,16 +1,18 @@
 import { create } from "zustand";
 
-import type { TerminalTab } from "@/workbench/tabs";
+import type { TerminalPane } from "@/workbench/tabs";
 
 export function broadcastTargets(
-  tabs: readonly TerminalTab[],
+  panes: readonly TerminalPane[],
   sourceId: string,
-): TerminalTab[] {
-  if (!tabs.some((tab) => tab.id === sourceId && tab.status === "connected")) {
+): TerminalPane[] {
+  if (
+    !panes.some((pane) => pane.id === sourceId && pane.status === "connected")
+  ) {
     return [];
   }
-  return tabs.filter(
-    (tab) => tab.id !== sourceId && tab.status === "connected",
+  return panes.filter(
+    (pane) => pane.id !== sourceId && pane.status === "connected",
   );
 }
 

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -169,6 +169,9 @@ export const en = {
     terminal: {
       newLocal: "New local terminal",
       toggleBroadcast: "Toggle terminal input broadcasting",
+      splitRight: "Split terminal right",
+      splitDown: "Split terminal down",
+      focusNextPane: "Focus next terminal pane",
     },
     view: {
       toggleSidebar: "Toggle sidebar",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -261,6 +261,13 @@ export const en = {
       wholeWord: "Match whole word",
       regex: "Use regular expression",
     },
+    menu: {
+      paste: "Paste",
+      selectAll: "Select all",
+      clear: "Clear terminal",
+      closePane: "Close pane",
+      closeTerminal: "Close terminal",
+    },
   },
 
   hosts: {

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -268,6 +268,8 @@ export const en = {
       closePane: "Close pane",
       closeTerminal: "Close terminal",
     },
+    splitLimitReachedRow: "You can split into at most {count} panes horizontally",
+    splitLimitReachedColumn: "You can split into at most {count} panes vertically",
   },
 
   hosts: {

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -268,8 +268,10 @@ export const en = {
       closePane: "Close pane",
       closeTerminal: "Close terminal",
     },
-    splitLimitReachedRow: "You can split into at most {count} panes horizontally",
-    splitLimitReachedColumn: "You can split into at most {count} panes vertically",
+    splitLimitReachedRow:
+      "You can split into at most {count} panes horizontally",
+    splitLimitReachedColumn:
+      "You can split into at most {count} panes vertically",
   },
 
   hosts: {

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -166,6 +166,9 @@ export const zhCN: Dictionary = {
     terminal: {
       newLocal: "新建本地终端",
       toggleBroadcast: "切换终端输入广播",
+      splitRight: "向右拆分终端",
+      splitDown: "向下拆分终端",
+      focusNextPane: "聚焦下一个终端窗格",
     },
     view: {
       toggleSidebar: "切换侧边栏",

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -264,6 +264,8 @@ export const zhCN: Dictionary = {
       closePane: "关闭窗格",
       closeTerminal: "关闭终端",
     },
+    splitLimitReachedRow: "水平方向最多只能拆分成 {count} 个窗格",
+    splitLimitReachedColumn: "垂直方向最多只能拆分成 {count} 个窗格",
   },
 
   hosts: {

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -257,6 +257,13 @@ export const zhCN: Dictionary = {
       wholeWord: "全字匹配",
       regex: "使用正则表达式",
     },
+    menu: {
+      paste: "粘贴",
+      selectAll: "全选",
+      clear: "清屏",
+      closePane: "关闭窗格",
+      closeTerminal: "关闭终端",
+    },
   },
 
   hosts: {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -229,14 +229,6 @@
       display: none;
     }
   }
-
-  .xterm {
-    padding-left: 20px;
-  }
-  .xterm .xterm-scrollable-element {
-    margin-left: -20px;
-    padding-left: 20px;
-  }
 }
 
 @utility scrollbar-none {

--- a/src/workbench/EditorArea.tsx
+++ b/src/workbench/EditorArea.tsx
@@ -60,6 +60,12 @@ const TerminalEditor = lazy(() =>
   })),
 );
 
+const TerminalTabActions = lazy(() =>
+  import("@/features/terminal/TerminalEditor").then((module) => ({
+    default: module.TerminalTabActions,
+  })),
+);
+
 interface TabDragPointer {
   clientX: number;
   clientY: number;
@@ -82,6 +88,9 @@ export function EditorArea() {
   const moveTab = useTabsStore((s) => s.moveTab);
   const saveFile = useTabsStore((s) => s.saveFile);
   const openPalette = useOverlayStore((s) => s.openPalette);
+  const activeTab = tabs.find((tab) => tab.id === activeId);
+  const activePaneId =
+    activeTab?.kind === "terminal" ? activeTab.activePaneId : null;
   const stripRef = useRef<HTMLDivElement>(null);
   const preserveTabFocusRef = useRef(false);
   const [dragState, setDragState] = useState<TabDragState | null>(null);
@@ -270,12 +279,9 @@ export function EditorArea() {
       preserveTabFocusRef.current = false;
       return;
     }
-    const active = useTabsStore
-      .getState()
-      .tabs.find((tab) => tab.id === activeId);
-    if (active?.kind === "terminal") focusTerminal(active.activePaneId);
+    if (activePaneId) focusTerminal(activePaneId);
     else focusFileEditor(activeId);
-  }, [activeId]);
+  }, [activeId, activePaneId]);
 
   if (tabs.length === 0) return <Watermark />;
 
@@ -327,6 +333,11 @@ export function EditorArea() {
                 />
               ))}
             </TabsList>
+            {activeTab?.kind === "terminal" && (
+              <Suspense fallback={null}>
+                <TerminalTabActions paneId={activeTab.activePaneId} />
+              </Suspense>
+            )}
             <Tooltip content={t("editor.newSession")}>
               <button
                 type="button"

--- a/src/workbench/EditorArea.tsx
+++ b/src/workbench/EditorArea.tsx
@@ -60,12 +60,6 @@ const TerminalEditor = lazy(() =>
   })),
 );
 
-const TerminalTabActions = lazy(() =>
-  import("@/features/terminal/TerminalEditor").then((module) => ({
-    default: module.TerminalTabActions,
-  })),
-);
-
 interface TabDragPointer {
   clientX: number;
   clientY: number;
@@ -333,11 +327,6 @@ export function EditorArea() {
                 />
               ))}
             </TabsList>
-            {activeTab?.kind === "terminal" && (
-              <Suspense fallback={null}>
-                <TerminalTabActions paneId={activeTab.activePaneId} />
-              </Suspense>
-            )}
             <Tooltip content={t("editor.newSession")}>
               <button
                 type="button"

--- a/src/workbench/EditorArea.tsx
+++ b/src/workbench/EditorArea.tsx
@@ -40,7 +40,9 @@ import {
   WORKBENCH_TAB_STRIP_GUTTER_CLASS,
 } from "./tab-styles";
 import {
+  activePane,
   isFileDirty,
+  tabTitle,
   useTabsStore,
   type EditorTab,
   type FileTab,
@@ -268,8 +270,11 @@ export function EditorArea() {
       preserveTabFocusRef.current = false;
       return;
     }
-    focusTerminal(activeId);
-    focusFileEditor(activeId);
+    const active = useTabsStore
+      .getState()
+      .tabs.find((tab) => tab.id === activeId);
+    if (active?.kind === "terminal") focusTerminal(active.activePaneId);
+    else focusFileEditor(activeId);
   }, [activeId]);
 
   if (tabs.length === 0) return <Watermark />;
@@ -427,17 +432,17 @@ function TabItem({
     active: boolean;
   } | null>(null);
 
-  const title = tab.title;
+  const title = tabTitle(tab);
   const dirty = tab.kind === "file" && isFileDirty(tab);
+  const pane = tab.kind === "terminal" ? activePane(tab) : null;
 
-  const reopen =
-    tab.kind === "terminal"
-      ? tab.target === "local"
-        ? () => openLocalTerminal()
-        : tab.target === "ssh-adhoc" && tab.adhoc
-          ? () => openAdhocTerminal(tab.adhoc!)
-          : () => openTerminal({ id: tab.hostId, label: tab.title })
-      : undefined;
+  const reopen = pane
+    ? pane.target === "local"
+      ? () => openLocalTerminal()
+      : pane.target === "ssh-adhoc" && pane.adhoc
+        ? () => openAdhocTerminal(pane.adhoc!)
+        : () => openTerminal({ id: pane.hostId, label: pane.title })
+    : undefined;
 
   const handlePointerDown = (e: ReactPointerEvent<HTMLDivElement>) => {
     if (
@@ -529,14 +534,14 @@ function TabItem({
           onKeyboardMove(e.key === "ArrowLeft" ? -1 : 1);
         }}
       >
-        {tab.kind === "terminal" ? (
+        {tab.kind === "terminal" && pane ? (
           <span className="relative flex shrink-0 items-center justify-center">
             <TerminalSquare className="size-3.5" />
             <span
               className={cn(
                 "absolute -bottom-0.5 -right-0.5 size-1.5 rounded-full ring-2",
                 "ring-[var(--tab-background)]",
-                STATUS_DOT_CLASS[tab.status],
+                STATUS_DOT_CLASS[pane.status],
               )}
             />
           </span>
@@ -545,6 +550,12 @@ function TabItem({
         )}
 
         <span className="min-w-0 max-w-36 truncate text-left">{title}</span>
+
+        {tab.kind === "terminal" && tab.panes.length > 1 && (
+          <span className="shrink-0 rounded-sm bg-accent px-1 font-mono text-[10px] leading-4 text-muted-foreground">
+            {tab.panes.length}
+          </span>
+        )}
 
         {dirty && (
           <span
@@ -583,7 +594,7 @@ function TabDragGhost({
   tab: EditorTab;
   dragState: TabDragState;
 }) {
-  const title = tab.title;
+  const title = tabTitle(tab);
   const dirty = tab.kind === "file" && isFileDirty(tab);
 
   return (
@@ -603,7 +614,7 @@ function TabDragGhost({
           <span
             className={cn(
               "absolute -bottom-0.5 -right-0.5 size-1.5 rounded-full ring-2 ring-list-active",
-              STATUS_DOT_CLASS[tab.status],
+              STATUS_DOT_CLASS[activePane(tab).status],
             )}
           />
         </span>

--- a/src/workbench/StatusBar.tsx
+++ b/src/workbench/StatusBar.tsx
@@ -19,7 +19,7 @@ import { useUpdateStatus } from "@/features/updates/api";
 import { useLayoutStore } from "./layout";
 import { useOverlayStore } from "./overlays";
 import { STATUS_DOT_CLASS } from "./tab-styles";
-import { targetTerminalId, terminalTabs, useTabsStore } from "./tabs";
+import { findPane, targetPaneId, useTabsStore } from "./tabs";
 
 export function StatusBar() {
   const { t } = useI18n();
@@ -68,11 +68,11 @@ function SessionItem() {
   const { t } = useI18n();
   const tabs = useTabsStore((s) => s.tabs);
   const activeId = useTabsStore((s) => s.activeId);
-  const lastTerminalId = useTabsStore((s) => s.lastTerminalId);
+  const lastPaneId = useTabsStore((s) => s.lastPaneId);
   const setActive = useTabsStore((s) => s.setActive);
 
-  const id = targetTerminalId({ tabs, activeId, lastTerminalId });
-  const session = terminalTabs(tabs).find((x) => x.id === id);
+  const id = targetPaneId({ tabs, activeId, lastPaneId });
+  const session = findPane(tabs, id);
   if (!session) return null;
 
   return (
@@ -93,12 +93,12 @@ function MonitorItem() {
   const { t } = useI18n();
   const tabs = useTabsStore((s) => s.tabs);
   const activeId = useTabsStore((s) => s.activeId);
-  const lastTerminalId = useTabsStore((s) => s.lastTerminalId);
+  const lastPaneId = useTabsStore((s) => s.lastPaneId);
   const bySession = useMonitorStore((s) => s.bySession);
 
-  const id = targetTerminalId({ tabs, activeId, lastTerminalId });
+  const id = targetPaneId({ tabs, activeId, lastPaneId });
   if (!id) return null;
-  const session = terminalTabs(tabs).find((tab) => tab.id === id);
+  const session = findPane(tabs, id);
   const entry = bySession[id];
   if (!session || entry?.attempt !== session.attempt || !entry.stats) {
     return null;

--- a/src/workbench/commands.ts
+++ b/src/workbench/commands.ts
@@ -18,6 +18,14 @@ export interface WorkbenchCommand {
   run: () => void;
 }
 
+function splitActivePane(direction: "right" | "down") {
+  const state = useTabsStore.getState();
+  const active = state.tabs.find((tab) => tab.id === state.activeId);
+  if (active?.kind === "terminal") {
+    state.splitPane(active.activePaneId, direction);
+  }
+}
+
 export function useCommands(): WorkbenchCommand[] {
   const { t } = useI18n();
   const { setTheme } = useTheme();
@@ -54,6 +62,27 @@ export function useCommands(): WorkbenchCommand[] {
         label: t("commands.terminal.toggleBroadcast"),
         shortcut: ["mod", "shift", "B"],
         run: () => useBroadcastStore.getState().toggle(),
+      },
+      {
+        id: "terminal.splitRight",
+        categoryKey: "commands.category.terminal",
+        label: t("commands.terminal.splitRight"),
+        shortcut: ["mod", "\\"],
+        run: () => splitActivePane("right"),
+      },
+      {
+        id: "terminal.splitDown",
+        categoryKey: "commands.category.terminal",
+        label: t("commands.terminal.splitDown"),
+        shortcut: ["mod", "shift", "\\"],
+        run: () => splitActivePane("down"),
+      },
+      {
+        id: "terminal.focusNextPane",
+        categoryKey: "commands.category.terminal",
+        label: t("commands.terminal.focusNextPane"),
+        shortcut: ["mod", "]"],
+        run: () => useTabsStore.getState().focusPaneNext(1),
       },
       {
         id: "view.toggleSidebar",

--- a/src/workbench/keybindings.ts
+++ b/src/workbench/keybindings.ts
@@ -41,15 +41,35 @@ export function useKeybindings() {
         run(() => layout.toggleAux());
       } else if (key === "w" && !e.shiftKey) {
         run(() => {
-          if (overlays.overlay) overlays.close();
-          else if (tabs.activeId) tabs.close(tabs.activeId);
+          if (overlays.overlay) {
+            overlays.close();
+            return;
+          }
+          const active = tabs.tabs.find((t) => t.id === tabs.activeId);
+          if (active?.kind === "terminal" && active.panes.length > 1) {
+            tabs.closePane(active.activePaneId);
+          } else if (tabs.activeId) {
+            tabs.close(tabs.activeId);
+          }
         });
       } else if (e.shiftKey && (key === "[" || key === "]")) {
         run(() => tabs.activateNext(key === "]" ? 1 : -1));
+      } else if (key === "[" || key === "]") {
+        const active = tabs.tabs.find((t) => t.id === tabs.activeId);
+        if (active?.kind === "terminal" && active.panes.length > 1) {
+          run(() => tabs.focusPaneNext(key === "]" ? 1 : -1));
+        }
+      } else if (key === "\\") {
+        const active = tabs.tabs.find((t) => t.id === tabs.activeId);
+        if (active?.kind === "terminal") {
+          run(() =>
+            tabs.splitPane(active.activePaneId, e.shiftKey ? "down" : "right"),
+          );
+        }
       } else if (key === "f" && !e.shiftKey) {
         const active = tabs.tabs.find((t) => t.id === tabs.activeId);
         if (active?.kind === "terminal") {
-          run(() => useTerminalSearch.getState().open(active.id));
+          run(() => useTerminalSearch.getState().open(active.activePaneId));
         }
       } else if (key === "=" || key === "+") {
         run(() => useZoomStore.getState().zoomIn());

--- a/src/workbench/pane-layout.test.ts
+++ b/src/workbench/pane-layout.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  layoutExtent,
   layoutPaneIds,
   leafLayout,
   neighborPaneId,
@@ -97,6 +98,40 @@ describe("neighborPaneId", () => {
     expect(neighborPaneId(layout, "b")).toBe("c");
     expect(neighborPaneId(layout, "c")).toBe("b");
     expect(neighborPaneId(layout, "missing")).toBeNull();
+  });
+});
+
+describe("layoutExtent", () => {
+  it("reports 1 on both axes for a lone leaf", () => {
+    expect(layoutExtent(leafLayout("a"), "row")).toBe(1);
+    expect(layoutExtent(leafLayout("a"), "column")).toBe(1);
+  });
+
+  it("sums along the matching axis and takes the max across the other", () => {
+    let layout = split(leafLayout("a"), "a", "b", "row");
+    layout = split(layout, "b", "c", "row");
+    expect(layoutExtent(layout, "row")).toBe(3);
+    expect(layoutExtent(layout, "column")).toBe(1);
+  });
+
+  it("projects nested splits onto the grid axes", () => {
+    // row[a, column[b, row[d, e]], c] — visually 4 panes wide on the bottom band
+    let layout = split(leafLayout("a"), "a", "b", "row");
+    layout = split(layout, "b", "c", "row");
+    layout = split(layout, "b", "d", "column");
+    layout = split(layout, "d", "e", "row");
+    expect(layoutExtent(layout, "row")).toBe(4);
+    expect(layoutExtent(layout, "column")).toBe(2);
+  });
+
+  it("caps a full 3x2 grid at its outer dimensions", () => {
+    let layout = split(leafLayout("a"), "a", "b", "row");
+    layout = split(layout, "b", "c", "row");
+    layout = split(layout, "a", "d", "column");
+    layout = split(layout, "b", "e", "column");
+    layout = split(layout, "c", "f", "column");
+    expect(layoutExtent(layout, "row")).toBe(3);
+    expect(layoutExtent(layout, "column")).toBe(2);
   });
 });
 

--- a/src/workbench/pane-layout.test.ts
+++ b/src/workbench/pane-layout.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  layoutPaneIds,
+  leafLayout,
+  neighborPaneId,
+  removeLayoutPane,
+  resizeSplitNode,
+  splitLayout,
+  type PaneLayout,
+} from "./pane-layout";
+
+function split(layout: PaneLayout, target: string, next: string, dir: "row" | "column") {
+  return splitLayout(layout, target, next, dir);
+}
+
+describe("splitLayout", () => {
+  it("wraps a leaf into a two-child split", () => {
+    const layout = split(leafLayout("a"), "a", "b", "row");
+    expect(layout).toMatchObject({
+      type: "split",
+      direction: "row",
+      sizes: [0.5, 0.5],
+    });
+    expect(layoutPaneIds(layout)).toEqual(["a", "b"]);
+  });
+
+  it("inserts a sibling when the direction matches, halving the source size", () => {
+    let layout = split(leafLayout("a"), "a", "b", "row");
+    layout = resizeSplitNode(
+      layout,
+      (layout as Extract<PaneLayout, { type: "split" }>).id,
+      [0.6, 0.4],
+    );
+    layout = split(layout, "a", "c", "row");
+    expect(layoutPaneIds(layout)).toEqual(["a", "c", "b"]);
+    expect(
+      (layout as Extract<PaneLayout, { type: "split" }>).sizes,
+    ).toEqual([0.3, 0.3, 0.4]);
+  });
+
+  it("nests a split when the direction differs", () => {
+    let layout = split(leafLayout("a"), "a", "b", "row");
+    layout = split(layout, "b", "c", "column");
+    const root = layout as Extract<PaneLayout, { type: "split" }>;
+    expect(root.direction).toBe("row");
+    expect(root.children[1]).toMatchObject({
+      type: "split",
+      direction: "column",
+    });
+    expect(layoutPaneIds(layout)).toEqual(["a", "b", "c"]);
+  });
+
+  it("returns the same node when the target is missing", () => {
+    const layout = split(leafLayout("a"), "a", "b", "row");
+    expect(split(layout, "missing", "c", "row")).toBe(layout);
+  });
+});
+
+describe("removeLayoutPane", () => {
+  it("collapses a two-child split back to a leaf", () => {
+    const layout = split(leafLayout("a"), "a", "b", "row");
+    expect(removeLayoutPane(layout, "b")).toEqual(leafLayout("a"));
+  });
+
+  it("renormalizes the remaining sizes", () => {
+    let layout = split(leafLayout("a"), "a", "b", "row");
+    layout = split(layout, "b", "c", "row");
+    const removed = removeLayoutPane(layout, "a") as Extract<
+      PaneLayout,
+      { type: "split" }
+    >;
+    expect(layoutPaneIds(removed)).toEqual(["b", "c"]);
+    expect(removed.sizes.reduce((sum, size) => sum + size, 0)).toBeCloseTo(1);
+  });
+
+  it("collapses nested splits left with a single child", () => {
+    let layout = split(leafLayout("a"), "a", "b", "row");
+    layout = split(layout, "b", "c", "column");
+    const removed = removeLayoutPane(layout, "c") as Extract<
+      PaneLayout,
+      { type: "split" }
+    >;
+    expect(removed.children[1]).toEqual(leafLayout("b"));
+    expect(layoutPaneIds(removed)).toEqual(["a", "b"]);
+  });
+
+  it("returns null when removing the last pane", () => {
+    expect(removeLayoutPane(leafLayout("a"), "a")).toBeNull();
+  });
+});
+
+describe("neighborPaneId", () => {
+  it("prefers the following pane, falling back to the previous one", () => {
+    let layout = split(leafLayout("a"), "a", "b", "row");
+    layout = split(layout, "b", "c", "row");
+    expect(neighborPaneId(layout, "b")).toBe("c");
+    expect(neighborPaneId(layout, "c")).toBe("b");
+    expect(neighborPaneId(layout, "missing")).toBeNull();
+  });
+});
+
+describe("resizeSplitNode", () => {
+  it("applies sizes only to the matching split and rejects length mismatches", () => {
+    let layout = split(leafLayout("a"), "a", "b", "row");
+    const id = (layout as Extract<PaneLayout, { type: "split" }>).id;
+    layout = resizeSplitNode(layout, id, [0.7, 0.3]);
+    expect(
+      (layout as Extract<PaneLayout, { type: "split" }>).sizes,
+    ).toEqual([0.7, 0.3]);
+    expect(resizeSplitNode(layout, id, [1])).toBe(layout);
+    expect(resizeSplitNode(layout, "other", [0.2, 0.8])).toBe(layout);
+  });
+});

--- a/src/workbench/pane-layout.test.ts
+++ b/src/workbench/pane-layout.test.ts
@@ -11,7 +11,12 @@ import {
   type PaneLayout,
 } from "./pane-layout";
 
-function split(layout: PaneLayout, target: string, next: string, dir: "row" | "column") {
+function split(
+  layout: PaneLayout,
+  target: string,
+  next: string,
+  dir: "row" | "column",
+) {
   return splitLayout(layout, target, next, dir);
 }
 
@@ -35,9 +40,9 @@ describe("splitLayout", () => {
     );
     layout = split(layout, "a", "c", "row");
     expect(layoutPaneIds(layout)).toEqual(["a", "c", "b"]);
-    expect(
-      (layout as Extract<PaneLayout, { type: "split" }>).sizes,
-    ).toEqual([0.3, 0.3, 0.4]);
+    expect((layout as Extract<PaneLayout, { type: "split" }>).sizes).toEqual([
+      0.3, 0.3, 0.4,
+    ]);
   });
 
   it("nests a split when the direction differs", () => {
@@ -140,9 +145,9 @@ describe("resizeSplitNode", () => {
     let layout = split(leafLayout("a"), "a", "b", "row");
     const id = (layout as Extract<PaneLayout, { type: "split" }>).id;
     layout = resizeSplitNode(layout, id, [0.7, 0.3]);
-    expect(
-      (layout as Extract<PaneLayout, { type: "split" }>).sizes,
-    ).toEqual([0.7, 0.3]);
+    expect((layout as Extract<PaneLayout, { type: "split" }>).sizes).toEqual([
+      0.7, 0.3,
+    ]);
     expect(resizeSplitNode(layout, id, [1])).toBe(layout);
     expect(resizeSplitNode(layout, "other", [0.2, 0.8])).toBe(layout);
   });

--- a/src/workbench/pane-layout.ts
+++ b/src/workbench/pane-layout.ts
@@ -106,6 +106,17 @@ export function resizeSplitNode(
     : { ...layout, children };
 }
 
+export function layoutExtent(
+  layout: PaneLayout,
+  axis: SplitDirection,
+): number {
+  if (layout.type === "leaf") return 1;
+  const extents = layout.children.map((child) => layoutExtent(child, axis));
+  return layout.direction === axis
+    ? extents.reduce((sum, n) => sum + n, 0)
+    : Math.max(...extents);
+}
+
 export function neighborPaneId(
   layout: PaneLayout,
   paneId: string,

--- a/src/workbench/pane-layout.ts
+++ b/src/workbench/pane-layout.ts
@@ -106,10 +106,7 @@ export function resizeSplitNode(
     : { ...layout, children };
 }
 
-export function layoutExtent(
-  layout: PaneLayout,
-  axis: SplitDirection,
-): number {
+export function layoutExtent(layout: PaneLayout, axis: SplitDirection): number {
   if (layout.type === "leaf") return 1;
   const extents = layout.children.map((child) => layoutExtent(child, axis));
   return layout.direction === axis

--- a/src/workbench/pane-layout.ts
+++ b/src/workbench/pane-layout.ts
@@ -1,0 +1,117 @@
+export type SplitDirection = "row" | "column";
+
+export type PaneLayout =
+  | { type: "leaf"; paneId: string }
+  | {
+      type: "split";
+      id: string;
+      direction: SplitDirection;
+      children: PaneLayout[];
+      sizes: number[];
+    };
+
+export function leafLayout(paneId: string): PaneLayout {
+  return { type: "leaf", paneId };
+}
+
+export function layoutPaneIds(layout: PaneLayout): string[] {
+  if (layout.type === "leaf") return [layout.paneId];
+  return layout.children.flatMap(layoutPaneIds);
+}
+
+export function splitLayout(
+  layout: PaneLayout,
+  targetPaneId: string,
+  newPaneId: string,
+  direction: SplitDirection,
+): PaneLayout {
+  if (layout.type === "leaf") {
+    if (layout.paneId !== targetPaneId) return layout;
+    return {
+      type: "split",
+      id: crypto.randomUUID(),
+      direction,
+      children: [layout, leafLayout(newPaneId)],
+      sizes: [0.5, 0.5],
+    };
+  }
+  if (layout.direction === direction) {
+    const index = layout.children.findIndex(
+      (child) => child.type === "leaf" && child.paneId === targetPaneId,
+    );
+    if (index !== -1) {
+      const children = [...layout.children];
+      const sizes = [...layout.sizes];
+      const half = sizes[index] / 2;
+      sizes[index] = half;
+      children.splice(index + 1, 0, leafLayout(newPaneId));
+      sizes.splice(index + 1, 0, half);
+      return { ...layout, children, sizes };
+    }
+  }
+  const children = layout.children.map((child) =>
+    splitLayout(child, targetPaneId, newPaneId, direction),
+  );
+  return children.every((child, i) => child === layout.children[i])
+    ? layout
+    : { ...layout, children };
+}
+
+export function removeLayoutPane(
+  layout: PaneLayout,
+  paneId: string,
+): PaneLayout | null {
+  if (layout.type === "leaf") {
+    return layout.paneId === paneId ? null : layout;
+  }
+  const children: PaneLayout[] = [];
+  const sizes: number[] = [];
+  let changed = false;
+  layout.children.forEach((child, i) => {
+    const next = removeLayoutPane(child, paneId);
+    if (next === null) {
+      changed = true;
+      return;
+    }
+    if (next !== child) changed = true;
+    children.push(next);
+    sizes.push(layout.sizes[i]);
+  });
+  if (!changed) return layout;
+  if (children.length === 0) return null;
+  if (children.length === 1) return children[0];
+  const total = sizes.reduce((sum, size) => sum + size, 0);
+  return {
+    ...layout,
+    children,
+    sizes: sizes.map((size) => (total > 0 ? size / total : 1 / sizes.length)),
+  };
+}
+
+export function resizeSplitNode(
+  layout: PaneLayout,
+  splitId: string,
+  sizes: number[],
+): PaneLayout {
+  if (layout.type === "leaf") return layout;
+  if (layout.id === splitId) {
+    if (sizes.length !== layout.children.length) return layout;
+    return { ...layout, sizes };
+  }
+  const children = layout.children.map((child) =>
+    resizeSplitNode(child, splitId, sizes),
+  );
+  return children.every((child, i) => child === layout.children[i])
+    ? layout
+    : { ...layout, children };
+}
+
+export function neighborPaneId(
+  layout: PaneLayout,
+  paneId: string,
+): string | null {
+  const ids = layoutPaneIds(layout);
+  const index = ids.indexOf(paneId);
+  if (index === -1) return null;
+  return ids[index + 1] ?? ids[index - 1] ?? null;
+}

--- a/src/workbench/shortcuts.test.ts
+++ b/src/workbench/shortcuts.test.ts
@@ -27,6 +27,12 @@ describe("isWorkbenchShortcut", () => {
     expect(shortcut(key("{", { shiftKey: true, code: "BracketLeft" }))).toBe(
       true,
     );
+    expect(shortcut(key("[", { code: "BracketLeft" }))).toBe(true);
+    expect(shortcut(key("]", { code: "BracketRight" }))).toBe(true);
+    expect(shortcut(key("\\", { code: "Backslash" }))).toBe(true);
+    expect(shortcut(key("|", { shiftKey: true, code: "Backslash" }))).toBe(
+      true,
+    );
     expect(shortcut(key("+", { shiftKey: true }))).toBe(true);
   });
 

--- a/src/workbench/shortcuts.ts
+++ b/src/workbench/shortcuts.ts
@@ -1,6 +1,7 @@
 export function workbenchShortcutKey(event: KeyboardEvent): string {
   if (event.code === "BracketLeft") return "[";
   if (event.code === "BracketRight") return "]";
+  if (event.code === "Backslash") return "\\";
   return event.key.toLowerCase();
 }
 
@@ -19,7 +20,8 @@ export function isWorkbenchShortcut(
   if (key === ",") return !event.shiftKey;
   if (key === "t") return event.shiftKey;
   if (["j", "l", "w", "f"].includes(key)) return !event.shiftKey;
-  if (key === "[" || key === "]") return event.shiftKey;
+  if (key === "[" || key === "]") return true;
+  if (key === "\\") return true;
   return (
     key === "=" || key === "+" || key === "-" || key === "_" || key === "0"
   );

--- a/src/workbench/tabs.test.ts
+++ b/src/workbench/tabs.test.ts
@@ -128,14 +128,76 @@ describe("splitPane", () => {
   });
 
   it("counts panes toward the session limit", () => {
-    const first = openHost("a");
-    for (let i = 1; i < MAX_TERMINAL_SESSIONS; i++) {
-      expect(useTabsStore.getState().splitPane(first, "right")).not.toBeNull();
+    const roots = Array.from({ length: MAX_TERMINAL_SESSIONS / 2 }, (_, i) =>
+      openHost(String(i)),
+    );
+    for (const root of roots) {
+      expect(useTabsStore.getState().splitPane(root, "right")).not.toBeNull();
     }
-    expect(useTabsStore.getState().splitPane(first, "down")).toBeNull();
     expect(terminalPanes(useTabsStore.getState().tabs)).toHaveLength(
       MAX_TERMINAL_SESSIONS,
     );
+    expect(useTabsStore.getState().splitPane(roots[0]!, "down")).toBeNull();
+    expect(terminalPanes(useTabsStore.getState().tabs)).toHaveLength(
+      MAX_TERMINAL_SESSIONS,
+    );
+  });
+
+  it("limits horizontal splits to three panes", () => {
+    const first = openHost("a");
+    const second = useTabsStore.getState().splitPane(first, "right")!;
+    const third = useTabsStore.getState().splitPane(second, "right")!;
+    expect(terminalPanes(useTabsStore.getState().tabs)).toHaveLength(3);
+
+    expect(useTabsStore.getState().splitPane(third, "right")).toBeNull();
+    expect(terminalPanes(useTabsStore.getState().tabs)).toHaveLength(3);
+  });
+
+  it("limits vertical splits to two panes", () => {
+    const first = openHost("a");
+    const second = useTabsStore.getState().splitPane(first, "down")!;
+    expect(terminalPanes(useTabsStore.getState().tabs)).toHaveLength(2);
+
+    expect(useTabsStore.getState().splitPane(second, "down")).toBeNull();
+    expect(terminalPanes(useTabsStore.getState().tabs)).toHaveLength(2);
+  });
+
+  it("allows a nested vertical split inside a full horizontal row", () => {
+    const first = openHost("a");
+    const second = useTabsStore.getState().splitPane(first, "right")!;
+    useTabsStore.getState().splitPane(second, "right");
+    expect(terminalPanes(useTabsStore.getState().tabs)).toHaveLength(3);
+
+    expect(useTabsStore.getState().splitPane(second, "down")).not.toBeNull();
+    expect(terminalPanes(useTabsStore.getState().tabs)).toHaveLength(4);
+  });
+
+  it("blocks a nested split that would widen the grid past the column cap", () => {
+    const first = openHost("a");
+    const second = useTabsStore.getState().splitPane(first, "right")!;
+    useTabsStore.getState().splitPane(second, "right");
+    const nested = useTabsStore.getState().splitPane(second, "down")!;
+    expect(terminalPanes(useTabsStore.getState().tabs)).toHaveLength(4);
+
+    // Splitting the nested pane sideways would make the bottom band 4 wide.
+    expect(useTabsStore.getState().splitPane(nested, "right")).toBeNull();
+    expect(terminalPanes(useTabsStore.getState().tabs)).toHaveLength(4);
+  });
+
+  it("permits building a full 3x2 grid but no further", () => {
+    const cols = [openHost("a")];
+    cols.push(useTabsStore.getState().splitPane(cols[0]!, "right")!);
+    cols.push(useTabsStore.getState().splitPane(cols[1]!, "right")!);
+    for (const col of cols) {
+      expect(useTabsStore.getState().splitPane(col, "down")).not.toBeNull();
+    }
+    expect(terminalPanes(useTabsStore.getState().tabs)).toHaveLength(6);
+
+    for (const col of cols) {
+      expect(useTabsStore.getState().splitPane(col, "down")).toBeNull();
+      expect(useTabsStore.getState().splitPane(col, "right")).toBeNull();
+    }
+    expect(terminalPanes(useTabsStore.getState().tabs)).toHaveLength(6);
   });
 });
 

--- a/src/workbench/tabs.test.ts
+++ b/src/workbench/tabs.test.ts
@@ -439,9 +439,7 @@ describe("moveTab", () => {
     useTabsStore.getState().moveTab(tabIdOf(a), 2);
 
     const reorderedTabs = useTabsStore.getState().tabs;
-    expect(reorderedTabs.map((tab) => tab.id)).toEqual(
-      [b, c, a].map(tabIdOf),
-    );
+    expect(reorderedTabs.map((tab) => tab.id)).toEqual([b, c, a].map(tabIdOf));
     expect(useTabsStore.getState().activeId).toBe(tabIdOf(b));
   });
 
@@ -460,9 +458,9 @@ describe("moveTab", () => {
       .getState()
       .tabs.find((tab) => tab.id === tabIdOf(connected));
     expect(reorderedTab).toBe(connectedTab);
-    expect(
-      terminalPanes([reorderedTab!]).map((pane) => pane.status),
-    ).toEqual(["connected"]);
+    expect(terminalPanes([reorderedTab!]).map((pane) => pane.status)).toEqual([
+      "connected",
+    ]);
     expect(useTabsStore.getState().tabs.map((tab) => tab.id)).toEqual(
       [connecting, connected].map(tabIdOf),
     );

--- a/src/workbench/tabs.test.ts
+++ b/src/workbench/tabs.test.ts
@@ -6,6 +6,9 @@ vi.mock("@/lib/ipc", () => ({
       disconnect: vi.fn(() => Promise.resolve()),
       send: vi.fn(() => Promise.resolve()),
     },
+    pty: {
+      close: vi.fn(() => Promise.resolve()),
+    },
     sftp: {
       readText: vi.fn(() => new Promise(() => {})),
       writeText: vi.fn(() => Promise.resolve()),
@@ -24,11 +27,14 @@ import {
   unregisterSession,
 } from "@/features/terminal/sessions";
 import type { TerminalSession } from "@/features/terminal/session";
+import { layoutPaneIds } from "./pane-layout";
 import {
   isFileDirty,
   MAX_FILE_TABS,
-  MAX_TERMINAL_TABS,
-  targetTerminalId,
+  MAX_TERMINAL_SESSIONS,
+  paneTab,
+  targetPaneId,
+  terminalPanes,
   terminalTabs,
   useTabsStore,
 } from "./tabs";
@@ -37,9 +43,15 @@ import type { FileTab } from "./tabs";
 const host = (id: string) => ({ id, label: `host-${id}` });
 
 function openHost(id: string): string {
-  const tabId = useTabsStore.getState().openTerminal(host(id));
-  if (!tabId) throw new Error("Expected terminal tab to open");
-  return tabId;
+  const paneId = useTabsStore.getState().openTerminal(host(id));
+  if (!paneId) throw new Error("Expected terminal tab to open");
+  return paneId;
+}
+
+function tabIdOf(paneId: string): string {
+  const tab = paneTab(useTabsStore.getState().tabs, paneId);
+  if (!tab) throw new Error(`Expected a tab containing pane ${paneId}`);
+  return tab.id;
 }
 
 beforeEach(() => {
@@ -48,34 +60,34 @@ beforeEach(() => {
   useTabsStore.setState({
     tabs: [],
     activeId: null,
-    lastTerminalId: null,
+    lastPaneId: null,
     pendingCloseId: null,
     pendingWindowClose: false,
   });
 });
 
 describe("openTerminal", () => {
-  it("appends the tab, activates it, and tracks it as last terminal", () => {
-    const id = openHost("a");
+  it("appends the tab, activates it, and tracks its pane as last pane", () => {
+    const paneId = openHost("a");
     const s = useTabsStore.getState();
     expect(s.tabs).toHaveLength(1);
-    expect(s.activeId).toBe(id);
-    expect(s.lastTerminalId).toBe(id);
+    expect(s.activeId).toBe(tabIdOf(paneId));
+    expect(s.lastPaneId).toBe(paneId);
   });
 
-  it("rejects new terminal tabs after reaching the limit", () => {
+  it("rejects new terminal sessions after reaching the limit", () => {
     const store = useTabsStore.getState();
-    for (let i = 0; i < MAX_TERMINAL_TABS; i++) {
+    for (let i = 0; i < MAX_TERMINAL_SESSIONS; i++) {
       expect(store.openTerminal(host(String(i)))).not.toBeNull();
     }
 
     expect(store.openLocalTerminal()).toBeNull();
-    expect(useTabsStore.getState().tabs).toHaveLength(MAX_TERMINAL_TABS);
+    expect(useTabsStore.getState().tabs).toHaveLength(MAX_TERMINAL_SESSIONS);
   });
 
   it("allows another terminal after one is closed", () => {
     const store = useTabsStore.getState();
-    const ids = Array.from({ length: MAX_TERMINAL_TABS }, (_, i) =>
+    const ids = Array.from({ length: MAX_TERMINAL_SESSIONS }, (_, i) =>
       openHost(String(i)),
     );
 
@@ -88,7 +100,97 @@ describe("openTerminal", () => {
         username: "me",
       }),
     ).not.toBeNull();
-    expect(useTabsStore.getState().tabs).toHaveLength(MAX_TERMINAL_TABS);
+    expect(useTabsStore.getState().tabs).toHaveLength(MAX_TERMINAL_SESSIONS);
+  });
+});
+
+describe("splitPane", () => {
+  it("clones the source connection into a sibling pane and focuses it", () => {
+    const source = openHost("a");
+    const split = useTabsStore.getState().splitPane(source, "right");
+
+    expect(split).not.toBeNull();
+    const s = useTabsStore.getState();
+    expect(s.tabs).toHaveLength(1);
+    const tab = terminalTabs(s.tabs)[0];
+    expect(tab.panes).toHaveLength(2);
+    expect(tab.activePaneId).toBe(split);
+    expect(s.lastPaneId).toBe(split);
+    expect(layoutPaneIds(tab.layout)).toEqual([source, split]);
+    const clone = tab.panes.find((pane) => pane.id === split)!;
+    expect(clone).toMatchObject({
+      target: "ssh",
+      hostId: "a",
+      title: "host-a",
+      status: "idle",
+      attempt: 0,
+    });
+  });
+
+  it("counts panes toward the session limit", () => {
+    const first = openHost("a");
+    for (let i = 1; i < MAX_TERMINAL_SESSIONS; i++) {
+      expect(useTabsStore.getState().splitPane(first, "right")).not.toBeNull();
+    }
+    expect(useTabsStore.getState().splitPane(first, "down")).toBeNull();
+    expect(terminalPanes(useTabsStore.getState().tabs)).toHaveLength(
+      MAX_TERMINAL_SESSIONS,
+    );
+  });
+});
+
+describe("closePane", () => {
+  it("collapses back to a single pane and refocuses the neighbor", () => {
+    const source = openHost("a");
+    const split = useTabsStore.getState().splitPane(source, "right")!;
+
+    useTabsStore.getState().closePane(split);
+
+    const s = useTabsStore.getState();
+    const tab = terminalTabs(s.tabs)[0];
+    expect(tab.panes.map((pane) => pane.id)).toEqual([source]);
+    expect(tab.layout).toEqual({ type: "leaf", paneId: source });
+    expect(tab.activePaneId).toBe(source);
+    expect(s.lastPaneId).toBe(source);
+  });
+
+  it("closes the whole tab when the last pane closes", () => {
+    const source = openHost("a");
+    useTabsStore.getState().closePane(source);
+    expect(useTabsStore.getState().tabs).toHaveLength(0);
+    expect(ipc.ssh.disconnect).toHaveBeenCalledWith(source, 0);
+  });
+});
+
+describe("focusPane", () => {
+  it("focusPaneNext cycles panes in layout order", () => {
+    const a = openHost("a");
+    const b = useTabsStore.getState().splitPane(a, "right")!;
+    const c = useTabsStore.getState().splitPane(b, "down")!;
+
+    useTabsStore.getState().focusPaneNext(1);
+    expect(paneTab(useTabsStore.getState().tabs, a)!.activePaneId).toBe(a);
+    useTabsStore.getState().focusPaneNext(-1);
+    expect(paneTab(useTabsStore.getState().tabs, a)!.activePaneId).toBe(c);
+    useTabsStore.getState().focusPaneNext(-1);
+    expect(paneTab(useTabsStore.getState().tabs, a)!.activePaneId).toBe(b);
+  });
+
+  it("setActive accepts a pane id and activates its tab and pane", () => {
+    const a = openHost("a");
+    const b = useTabsStore.getState().splitPane(a, "right")!;
+    openHost("other");
+
+    useTabsStore.getState().setActive(a);
+    let s = useTabsStore.getState();
+    expect(s.activeId).toBe(tabIdOf(a));
+    expect(paneTab(s.tabs, a)!.activePaneId).toBe(a);
+    expect(s.lastPaneId).toBe(a);
+
+    useTabsStore.getState().setActive(b);
+    s = useTabsStore.getState();
+    expect(paneTab(s.tabs, b)!.activePaneId).toBe(b);
+    expect(s.lastPaneId).toBe(b);
   });
 });
 
@@ -125,9 +227,9 @@ describe("close", () => {
     const c = openHost("c");
     useTabsStore.getState().setActive(b);
     useTabsStore.getState().close(b);
-    expect(useTabsStore.getState().activeId).toBe(c);
+    expect(useTabsStore.getState().activeId).toBe(tabIdOf(c));
     useTabsStore.getState().close(c);
-    expect(useTabsStore.getState().activeId).toBe(a);
+    expect(useTabsStore.getState().activeId).toBe(tabIdOf(a));
   });
 
   it("keeps the active tab when closing an inactive one", () => {
@@ -135,15 +237,24 @@ describe("close", () => {
     const b = openHost("b");
     useTabsStore.getState().setActive(b);
     useTabsStore.getState().close(a);
-    expect(useTabsStore.getState().activeId).toBe(b);
+    expect(useTabsStore.getState().activeId).toBe(tabIdOf(b));
   });
 
-  it("repoints lastTerminalId to the nearest surviving terminal", () => {
+  it("repoints lastPaneId to the nearest surviving terminal pane", () => {
     const a = openHost("a");
     const b = openHost("b");
     useTabsStore.getState().setActive(b);
     useTabsStore.getState().close(b);
-    expect(useTabsStore.getState().lastTerminalId).toBe(a);
+    expect(useTabsStore.getState().lastPaneId).toBe(a);
+  });
+
+  it("disposes every pane when a split tab closes", () => {
+    const a = openHost("a");
+    const b = useTabsStore.getState().splitPane(a, "right")!;
+    useTabsStore.getState().close(tabIdOf(a));
+    expect(useTabsStore.getState().tabs).toHaveLength(0);
+    expect(ipc.ssh.disconnect).toHaveBeenCalledWith(a, 0);
+    expect(ipc.ssh.disconnect).toHaveBeenCalledWith(b, 0);
   });
 
   it("deflects a dirty file close into pendingCloseId", () => {
@@ -250,9 +361,9 @@ describe("activateNext", () => {
     const a = openHost("a");
     const b = openHost("b");
     useTabsStore.getState().activateNext(1);
-    expect(useTabsStore.getState().activeId).toBe(a);
+    expect(useTabsStore.getState().activeId).toBe(tabIdOf(a));
     useTabsStore.getState().activateNext(-1);
-    expect(useTabsStore.getState().activeId).toBe(b);
+    expect(useTabsStore.getState().activeId).toBe(tabIdOf(b));
   });
 });
 
@@ -263,11 +374,13 @@ describe("moveTab", () => {
     const c = openHost("c");
     useTabsStore.getState().setActive(b);
 
-    useTabsStore.getState().moveTab(a, 2);
+    useTabsStore.getState().moveTab(tabIdOf(a), 2);
 
     const reorderedTabs = useTabsStore.getState().tabs;
-    expect(reorderedTabs.map((tab) => tab.id)).toEqual([b, c, a]);
-    expect(useTabsStore.getState().activeId).toBe(b);
+    expect(reorderedTabs.map((tab) => tab.id)).toEqual(
+      [b, c, a].map(tabIdOf),
+    );
+    expect(useTabsStore.getState().activeId).toBe(tabIdOf(b));
   });
 
   it("retains terminal tab objects and their connection status", () => {
@@ -277,48 +390,63 @@ describe("moveTab", () => {
     store.setTerminalStatus(connected, "connected");
     const connectedTab = useTabsStore
       .getState()
-      .tabs.find((tab) => tab.id === connected);
+      .tabs.find((tab) => tab.id === tabIdOf(connected));
 
-    useTabsStore.getState().moveTab(connected, 1);
+    useTabsStore.getState().moveTab(tabIdOf(connected), 1);
 
     const reorderedTab = useTabsStore
       .getState()
-      .tabs.find((tab) => tab.id === connected);
+      .tabs.find((tab) => tab.id === tabIdOf(connected));
     expect(reorderedTab).toBe(connectedTab);
-    expect(reorderedTab).toMatchObject({ status: "connected" });
-    expect(useTabsStore.getState().tabs.map((tab) => tab.id)).toEqual([
-      connecting,
-      connected,
-    ]);
+    expect(
+      terminalPanes([reorderedTab!]).map((pane) => pane.status),
+    ).toEqual(["connected"]);
+    expect(useTabsStore.getState().tabs.map((tab) => tab.id)).toEqual(
+      [connecting, connected].map(tabIdOf),
+    );
   });
 
   it("clamps the destination and ignores unknown tabs", () => {
     const a = openHost("a");
     const b = openHost("b");
 
-    useTabsStore.getState().moveTab(a, 100);
-    expect(useTabsStore.getState().tabs.map((tab) => tab.id)).toEqual([b, a]);
+    useTabsStore.getState().moveTab(tabIdOf(a), 100);
+    expect(useTabsStore.getState().tabs.map((tab) => tab.id)).toEqual(
+      [b, a].map(tabIdOf),
+    );
 
     useTabsStore.getState().moveTab("missing", 0);
-    expect(useTabsStore.getState().tabs.map((tab) => tab.id)).toEqual([b, a]);
+    expect(useTabsStore.getState().tabs.map((tab) => tab.id)).toEqual(
+      [b, a].map(tabIdOf),
+    );
   });
 });
 
 describe("selectors", () => {
-  it("targetTerminalId prefers the active terminal, else the last one", () => {
+  it("targetPaneId prefers the active tab's pane, else the last one", () => {
     const store = useTabsStore.getState();
     const a = openHost("a");
     store.openFile({ connectionId: null, path: "/tmp/a", name: "a" });
-    expect(targetTerminalId(useTabsStore.getState())).toBe(a);
+    expect(targetPaneId(useTabsStore.getState())).toBe(a);
     useTabsStore.getState().setActive(a);
-    expect(targetTerminalId(useTabsStore.getState())).toBe(a);
+    expect(targetPaneId(useTabsStore.getState())).toBe(a);
   });
 
-  it("terminalTabs filters non-terminal tabs", () => {
+  it("targetPaneId follows the focused pane inside a split", () => {
+    const a = openHost("a");
+    const b = useTabsStore.getState().splitPane(a, "right")!;
+    expect(targetPaneId(useTabsStore.getState())).toBe(b);
+    useTabsStore.getState().focusPane(a);
+    expect(targetPaneId(useTabsStore.getState())).toBe(a);
+  });
+
+  it("terminalPanes flattens panes across terminal tabs only", () => {
     const store = useTabsStore.getState();
-    store.openTerminal(host("a"));
+    const a = openHost("a");
+    useTabsStore.getState().splitPane(a, "right");
     store.openFile({ connectionId: null, path: "/tmp/a", name: "a" });
     expect(terminalTabs(useTabsStore.getState().tabs)).toHaveLength(1);
+    expect(terminalPanes(useTabsStore.getState().tabs)).toHaveLength(2);
   });
 
   it("isFileDirty compares buffer against saved content", () => {
@@ -339,7 +467,7 @@ describe("selectors", () => {
 });
 
 describe("sendToTerminal", () => {
-  it("sends to a connected terminal and records scoped history", () => {
+  it("sends to the focused connected pane and records scoped history", () => {
     const id = openHost("a");
     const sendCommand = vi.fn();
     registerSession(id, { sendCommand } as unknown as TerminalSession);

--- a/src/workbench/tabs.ts
+++ b/src/workbench/tabs.ts
@@ -171,9 +171,7 @@ export function paneTab(
 }
 
 export function activePane(tab: TerminalTab): TerminalPane {
-  return (
-    tab.panes.find((pane) => pane.id === tab.activePaneId) ?? tab.panes[0]
-  );
+  return tab.panes.find((pane) => pane.id === tab.activePaneId) ?? tab.panes[0];
 }
 
 export function tabTitle(tab: EditorTab): string {
@@ -222,7 +220,9 @@ function localPaneTitle(tabs: EditorTab[]): string {
 export const useTabsStore = create<TabsState>((set, get) => {
   const canOpenSession = () => {
     if (terminalPanes(get().tabs).length < MAX_TERMINAL_SESSIONS) return true;
-    toast.warning(t("editor.tabLimitReached", { count: MAX_TERMINAL_SESSIONS }));
+    toast.warning(
+      t("editor.tabLimitReached", { count: MAX_TERMINAL_SESSIONS }),
+    );
     return false;
   };
 

--- a/src/workbench/tabs.ts
+++ b/src/workbench/tabs.ts
@@ -8,6 +8,7 @@ import { ipc } from "@/lib/ipc";
 import { errorMessage, toast } from "@/lib/toast";
 import type { Host, SshStatusKind } from "@/types/models";
 import {
+  layoutExtent,
   layoutPaneIds,
   leafLayout,
   neighborPaneId,
@@ -35,6 +36,10 @@ export type PaneSplitDirection = "right" | "down";
 
 export const MAX_TERMINAL_SESSIONS = 10;
 export const MAX_FILE_TABS = 10;
+export const MAX_PANES_PER_DIRECTION: Record<SplitDirection, number> = {
+  row: 3,
+  column: 2,
+};
 
 export interface AdhocTarget {
   host: string;
@@ -353,9 +358,25 @@ export const useTabsStore = create<TabsState>((set, get) => {
       const tab = paneTab(get().tabs, paneId);
       const source = tab?.panes.find((pane) => pane.id === paneId);
       if (!tab || !source) return null;
+      const splitDirection: SplitDirection =
+        direction === "right" ? "row" : "column";
+      const newPaneId = crypto.randomUUID();
+      const layout = splitLayout(tab.layout, paneId, newPaneId, splitDirection);
+      const limit = MAX_PANES_PER_DIRECTION[splitDirection];
+      if (layoutExtent(layout, splitDirection) > limit) {
+        toast.warning(
+          t(
+            splitDirection === "row"
+              ? "terminal.splitLimitReachedRow"
+              : "terminal.splitLimitReachedColumn",
+            { count: limit },
+          ),
+        );
+        return null;
+      }
       if (!canOpenSession()) return null;
       const pane: TerminalPane = {
-        id: crypto.randomUUID(),
+        id: newPaneId,
         target: source.target,
         hostId: source.hostId,
         adhoc: source.adhoc,
@@ -364,13 +385,10 @@ export const useTabsStore = create<TabsState>((set, get) => {
         status: "idle",
         attempt: 0,
       };
-      const splitDirection: SplitDirection =
-        direction === "right" ? "row" : "column";
       set((s) => ({
         tabs: s.tabs.map((current) => {
           if (current.id !== tab.id || !isTerminal(current)) return current;
-          const at =
-            current.panes.findIndex((item) => item.id === paneId) + 1;
+          const at = current.panes.findIndex((item) => item.id === paneId) + 1;
           return {
             ...current,
             panes: [
@@ -378,12 +396,7 @@ export const useTabsStore = create<TabsState>((set, get) => {
               pane,
               ...current.panes.slice(at),
             ],
-            layout: splitLayout(
-              current.layout,
-              paneId,
-              pane.id,
-              splitDirection,
-            ),
+            layout,
             activePaneId: pane.id,
           };
         }),

--- a/src/workbench/tabs.ts
+++ b/src/workbench/tabs.ts
@@ -7,6 +7,16 @@ import { translate } from "@/i18n/translate";
 import { ipc } from "@/lib/ipc";
 import { errorMessage, toast } from "@/lib/toast";
 import type { Host, SshStatusKind } from "@/types/models";
+import {
+  layoutPaneIds,
+  leafLayout,
+  neighborPaneId,
+  removeLayoutPane,
+  resizeSplitNode,
+  splitLayout,
+  type PaneLayout,
+  type SplitDirection,
+} from "./pane-layout";
 
 function t(
   key: Parameters<typeof translate>[1],
@@ -21,7 +31,9 @@ export type TerminalTarget = "ssh" | "local" | "ssh-adhoc";
 
 export type SendToTerminalResult = "sent" | "no-terminal" | "not-connected";
 
-export const MAX_TERMINAL_TABS = 10;
+export type PaneSplitDirection = "right" | "down";
+
+export const MAX_TERMINAL_SESSIONS = 10;
 export const MAX_FILE_TABS = 10;
 
 export interface AdhocTarget {
@@ -30,9 +42,7 @@ export interface AdhocTarget {
   username: string;
 }
 
-export interface TerminalTab {
-  kind: "terminal";
-
+export interface TerminalPane {
   id: string;
   target: TerminalTarget;
   hostId: string;
@@ -43,6 +53,15 @@ export interface TerminalTab {
   errorCode?: string | null;
 
   attempt: number;
+}
+
+export interface TerminalTab {
+  kind: "terminal";
+
+  id: string;
+  panes: TerminalPane[];
+  layout: PaneLayout;
+  activePaneId: string;
 }
 
 export interface FileTab {
@@ -71,13 +90,19 @@ interface TabsState {
   tabs: EditorTab[];
   activeId: string | null;
 
-  lastTerminalId: string | null;
+  lastPaneId: string | null;
 
   openTerminal: (host: Pick<Host, "id" | "label">) => string | null;
 
   openLocalTerminal: () => string | null;
 
   openAdhocTerminal: (target: AdhocTarget) => string | null;
+
+  splitPane: (paneId: string, direction: PaneSplitDirection) => string | null;
+  closePane: (paneId: string) => void;
+  focusPane: (paneId: string) => void;
+  focusPaneNext: (direction: 1 | -1) => void;
+  resizePanes: (tabId: string, splitId: string, sizes: number[]) => void;
 
   openFile: (file: {
     connectionId: string | null;
@@ -100,13 +125,13 @@ interface TabsState {
   activateNext: (direction: 1 | -1) => void;
 
   setTerminalStatus: (
-    id: string,
+    paneId: string,
     status: TerminalStatus,
     error?: string,
     errorCode?: string | null,
   ) => void;
 
-  reconnectTerminal: (id: string) => void;
+  reconnectTerminal: (paneId: string) => void;
 
   sendToTerminal: (command: string) => SendToTerminalResult;
 }
@@ -114,48 +139,125 @@ interface TabsState {
 const isTerminal = (tab: EditorTab): tab is TerminalTab =>
   tab.kind === "terminal";
 
-export function terminalTabs(tabs: EditorTab[]): TerminalTab[] {
+export function terminalTabs(tabs: readonly EditorTab[]): TerminalTab[] {
   return tabs.filter(isTerminal);
+}
+
+export function terminalPanes(tabs: readonly EditorTab[]): TerminalPane[] {
+  return terminalTabs(tabs).flatMap((tab) => tab.panes);
+}
+
+export function findPane(
+  tabs: readonly EditorTab[],
+  paneId: string | null,
+): TerminalPane | undefined {
+  if (!paneId) return undefined;
+  return terminalPanes(tabs).find((pane) => pane.id === paneId);
+}
+
+export function paneTab(
+  tabs: readonly EditorTab[],
+  paneId: string | null,
+): TerminalTab | undefined {
+  if (!paneId) return undefined;
+  return terminalTabs(tabs).find((tab) =>
+    tab.panes.some((pane) => pane.id === paneId),
+  );
+}
+
+export function activePane(tab: TerminalTab): TerminalPane {
+  return (
+    tab.panes.find((pane) => pane.id === tab.activePaneId) ?? tab.panes[0]
+  );
+}
+
+export function tabTitle(tab: EditorTab): string {
+  return tab.kind === "file" ? tab.title : activePane(tab).title;
 }
 
 function fileTabCount(tabs: EditorTab[]): number {
   return tabs.filter((tab) => tab.kind === "file").length;
 }
 
-function findOpenTerminal(tabs: EditorTab[], id: string | null) {
-  return tabs.find((t): t is TerminalTab => t.id === id && isTerminal(t));
-}
-
-function closestTerminalId(tabs: EditorTab[], closedIndex: number) {
+function closestPaneId(tabs: EditorTab[], closedIndex: number) {
   if (tabs.length === 0) return null;
 
   const rightStart = Math.max(0, Math.min(closedIndex, tabs.length - 1));
   for (let i = rightStart; i < tabs.length; i++) {
-    if (isTerminal(tabs[i])) return tabs[i].id;
+    const tab = tabs[i];
+    if (isTerminal(tab)) return tab.activePaneId;
   }
   const leftStart = Math.min(closedIndex - 1, tabs.length - 1);
   for (let i = leftStart; i >= 0; i--) {
-    if (isTerminal(tabs[i])) return tabs[i].id;
+    const tab = tabs[i];
+    if (isTerminal(tab)) return tab.activePaneId;
   }
   return null;
 }
 
-export function targetTerminalId(state: {
+export function targetPaneId(state: {
   tabs: EditorTab[];
   activeId: string | null;
-  lastTerminalId: string | null;
+  lastPaneId: string | null;
 }): string | null {
-  const active = state.tabs.find((t) => t.id === state.activeId);
-  if (active && isTerminal(active)) return active.id;
-  return findOpenTerminal(state.tabs, state.lastTerminalId)?.id ?? null;
+  const active = state.tabs.find((tab) => tab.id === state.activeId);
+  if (active && isTerminal(active)) return activePane(active).id;
+  return findPane(state.tabs, state.lastPaneId)?.id ?? null;
+}
+
+function localPaneTitle(tabs: EditorTab[]): string {
+  const count = terminalPanes(tabs).filter(
+    (pane) => pane.target === "local",
+  ).length;
+  return count === 0
+    ? t("terminal.local.title")
+    : `${t("terminal.local.title")} ${count + 1}`;
 }
 
 export const useTabsStore = create<TabsState>((set, get) => {
-  const canOpenTerminal = () => {
-    if (terminalTabs(get().tabs).length < MAX_TERMINAL_TABS) return true;
-    toast.warning(t("editor.tabLimitReached", { count: MAX_TERMINAL_TABS }));
+  const canOpenSession = () => {
+    if (terminalPanes(get().tabs).length < MAX_TERMINAL_SESSIONS) return true;
+    toast.warning(t("editor.tabLimitReached", { count: MAX_TERMINAL_SESSIONS }));
     return false;
   };
+
+  const releasePane = (pane: TerminalPane) => {
+    if (pane.target === "local") void ipc.pty.close(pane.id).catch(() => {});
+    else void ipc.ssh.disconnect(pane.id, pane.attempt).catch(() => {});
+    disposeSession(pane.id);
+    const search = useTerminalSearch.getState();
+    if (search.openFor === pane.id) search.close();
+  };
+
+  const openTab = (pane: TerminalPane): string => {
+    const tab: TerminalTab = {
+      kind: "terminal",
+      id: crypto.randomUUID(),
+      panes: [pane],
+      layout: leafLayout(pane.id),
+      activePaneId: pane.id,
+    };
+    set((s) => ({
+      tabs: [...s.tabs, tab],
+      activeId: tab.id,
+      lastPaneId: pane.id,
+    }));
+    return pane.id;
+  };
+
+  const patchPane = (paneId: string, patch: Partial<TerminalPane>) =>
+    set((s) => ({
+      tabs: s.tabs.map((tab) =>
+        isTerminal(tab) && tab.panes.some((pane) => pane.id === paneId)
+          ? {
+              ...tab,
+              panes: tab.panes.map((pane) =>
+                pane.id === paneId ? { ...pane, ...patch } : pane,
+              ),
+            }
+          : tab,
+      ),
+    }));
 
   const patchFile = (id: string, patch: Partial<FileTab>) =>
     set((s) => ({
@@ -164,10 +266,39 @@ export const useTabsStore = create<TabsState>((set, get) => {
       ),
     }));
 
+  const closeTab = (tab: EditorTab, opts?: { force?: boolean }) => {
+    if (!opts?.force && tab.kind === "file" && isFileDirty(tab)) {
+      set({ pendingCloseId: tab.id });
+      return;
+    }
+    if (isTerminal(tab)) {
+      for (const pane of tab.panes) releasePane(pane);
+    }
+    set((s) => {
+      const index = s.tabs.findIndex((t) => t.id === tab.id);
+      if (index === -1) return s;
+      const tabs = s.tabs.filter((t) => t.id !== tab.id);
+
+      const activeId =
+        s.activeId === tab.id
+          ? (tabs[Math.min(index, tabs.length - 1)]?.id ?? null)
+          : tabs.some((t) => t.id === s.activeId)
+            ? s.activeId
+            : null;
+      const active = tabs.find((t) => t.id === activeId);
+      const lastPaneId =
+        findPane(tabs, s.lastPaneId)?.id ??
+        (active && isTerminal(active)
+          ? active.activePaneId
+          : closestPaneId(tabs, index));
+      return { tabs, activeId, lastPaneId };
+    });
+  };
+
   return {
     tabs: [],
     activeId: null,
-    lastTerminalId: null,
+    lastPaneId: null,
     pendingCloseId: null,
     pendingWindowClose: false,
 
@@ -182,71 +313,148 @@ export const useTabsStore = create<TabsState>((set, get) => {
     clearPendingWindowClose: () => set({ pendingWindowClose: false }),
 
     openTerminal: (host) => {
-      if (!canOpenTerminal()) return null;
-      const id = crypto.randomUUID();
-      const tab: TerminalTab = {
-        kind: "terminal",
-        id,
+      if (!canOpenSession()) return null;
+      return openTab({
+        id: crypto.randomUUID(),
         target: "ssh",
         hostId: host.id,
         title: host.label,
         status: "idle",
         attempt: 0,
-      };
-      set((s) => ({
-        tabs: [...s.tabs, tab],
-        activeId: id,
-        lastTerminalId: id,
-      }));
-      return id;
+      });
     },
 
     openLocalTerminal: () => {
-      if (!canOpenTerminal()) return null;
-      const id = crypto.randomUUID();
-      const count = terminalTabs(get().tabs).filter(
-        (t) => t.target === "local",
-      ).length;
-      const tab: TerminalTab = {
-        kind: "terminal",
-        id,
+      if (!canOpenSession()) return null;
+      return openTab({
+        id: crypto.randomUUID(),
         target: "local",
         hostId: "",
-        title:
-          count === 0
-            ? t("terminal.local.title")
-            : `${t("terminal.local.title")} ${count + 1}`,
+        title: localPaneTitle(get().tabs),
         status: "idle",
         attempt: 0,
-      };
-      set((s) => ({
-        tabs: [...s.tabs, tab],
-        activeId: id,
-        lastTerminalId: id,
-      }));
-      return id;
+      });
     },
 
     openAdhocTerminal: (target) => {
-      if (!canOpenTerminal()) return null;
-      const id = crypto.randomUUID();
-      const tab: TerminalTab = {
-        kind: "terminal",
-        id,
+      if (!canOpenSession()) return null;
+      return openTab({
+        id: crypto.randomUUID(),
         target: "ssh-adhoc",
         hostId: "",
         adhoc: target,
         title: `${target.username}@${target.host}`,
         status: "idle",
         attempt: 0,
-      };
-      set((s) => ({
-        tabs: [...s.tabs, tab],
-        activeId: id,
-        lastTerminalId: id,
-      }));
-      return id;
+      });
     },
+
+    splitPane: (paneId, direction) => {
+      const tab = paneTab(get().tabs, paneId);
+      const source = tab?.panes.find((pane) => pane.id === paneId);
+      if (!tab || !source) return null;
+      if (!canOpenSession()) return null;
+      const pane: TerminalPane = {
+        id: crypto.randomUUID(),
+        target: source.target,
+        hostId: source.hostId,
+        adhoc: source.adhoc,
+        title:
+          source.target === "local" ? localPaneTitle(get().tabs) : source.title,
+        status: "idle",
+        attempt: 0,
+      };
+      const splitDirection: SplitDirection =
+        direction === "right" ? "row" : "column";
+      set((s) => ({
+        tabs: s.tabs.map((current) => {
+          if (current.id !== tab.id || !isTerminal(current)) return current;
+          const at =
+            current.panes.findIndex((item) => item.id === paneId) + 1;
+          return {
+            ...current,
+            panes: [
+              ...current.panes.slice(0, at),
+              pane,
+              ...current.panes.slice(at),
+            ],
+            layout: splitLayout(
+              current.layout,
+              paneId,
+              pane.id,
+              splitDirection,
+            ),
+            activePaneId: pane.id,
+          };
+        }),
+        activeId: tab.id,
+        lastPaneId: pane.id,
+      }));
+      return pane.id;
+    },
+
+    closePane: (paneId) => {
+      const tab = paneTab(get().tabs, paneId);
+      const pane = tab?.panes.find((item) => item.id === paneId);
+      if (!tab || !pane) return;
+      if (tab.panes.length === 1) {
+        closeTab(tab);
+        return;
+      }
+      const neighbor = neighborPaneId(tab.layout, paneId);
+      releasePane(pane);
+      set((s) => ({
+        tabs: s.tabs.map((current) => {
+          if (current.id !== tab.id || !isTerminal(current)) return current;
+          const layout = removeLayoutPane(current.layout, paneId);
+          if (!layout) return current;
+          return {
+            ...current,
+            panes: current.panes.filter((item) => item.id !== paneId),
+            layout,
+            activePaneId:
+              current.activePaneId === paneId
+                ? (neighbor ?? current.panes[0].id)
+                : current.activePaneId,
+          };
+        }),
+        lastPaneId: s.lastPaneId === paneId ? neighbor : s.lastPaneId,
+      }));
+    },
+
+    focusPane: (paneId) => {
+      const tab = paneTab(get().tabs, paneId);
+      if (!tab) return;
+      set((s) => ({
+        tabs: s.tabs.map((current) =>
+          current.id === tab.id && isTerminal(current)
+            ? { ...current, activePaneId: paneId }
+            : current,
+        ),
+        activeId: tab.id,
+        lastPaneId: paneId,
+      }));
+    },
+
+    focusPaneNext: (direction) => {
+      const { tabs, activeId, focusPane } = get();
+      const active = tabs.find((tab) => tab.id === activeId);
+      if (!active || !isTerminal(active) || active.panes.length < 2) return;
+      const ids = layoutPaneIds(active.layout);
+      const index = ids.indexOf(active.activePaneId);
+      const next =
+        ids[(Math.max(index, 0) + direction + ids.length) % ids.length];
+      if (next) focusPane(next);
+    },
+
+    resizePanes: (tabId, splitId, sizes) =>
+      set((s) => ({
+        tabs: s.tabs.map((tab) =>
+          tab.id === tabId && isTerminal(tab)
+            ? { ...tab, layout: resizeSplitNode(tab.layout, splitId, sizes) }
+            : tab,
+        ),
+      })),
 
     openFile: ({ connectionId, path, name }) => {
       const existing = get().tabs.find(
@@ -313,37 +521,11 @@ export const useTabsStore = create<TabsState>((set, get) => {
 
     close: (id, opts) => {
       const tab = get().tabs.find((t) => t.id === id);
-
-      if (!opts?.force && tab?.kind === "file" && isFileDirty(tab)) {
-        set({ pendingCloseId: id });
+      if (tab) {
+        closeTab(tab, opts);
         return;
       }
-      if (tab && isTerminal(tab)) {
-        if (tab.target === "local") void ipc.pty.close(id).catch(() => {});
-        else void ipc.ssh.disconnect(id, tab.attempt).catch(() => {});
-        disposeSession(id);
-        const search = useTerminalSearch.getState();
-        if (search.openFor === id) search.close();
-      }
-      set((s) => {
-        const index = s.tabs.findIndex((t) => t.id === id);
-        if (index === -1) return s;
-        const tabs = s.tabs.filter((t) => t.id !== id);
-
-        const activeId =
-          s.activeId === id
-            ? (tabs[Math.min(index, tabs.length - 1)]?.id ?? null)
-            : tabs.some((t) => t.id === s.activeId)
-              ? s.activeId
-              : null;
-        const active = tabs.find((t) => t.id === activeId);
-        const lastTerminalId =
-          findOpenTerminal(tabs, s.lastTerminalId)?.id ??
-          (active && isTerminal(active)
-            ? active.id
-            : closestTerminalId(tabs, index));
-        return { tabs, activeId, lastTerminalId };
-      });
+      if (findPane(get().tabs, id)) get().closePane(id);
     },
 
     moveTab: (id, toIndex) =>
@@ -364,10 +546,22 @@ export const useTabsStore = create<TabsState>((set, get) => {
     setActive: (id) =>
       set((s) => {
         const tab = s.tabs.find((t) => t.id === id);
-        if (!tab) return s;
+        if (tab) {
+          return {
+            activeId: id,
+            lastPaneId: isTerminal(tab) ? tab.activePaneId : s.lastPaneId,
+          };
+        }
+        const owner = paneTab(s.tabs, id);
+        if (!owner) return s;
         return {
-          activeId: id,
-          lastTerminalId: isTerminal(tab) ? tab.id : s.lastTerminalId,
+          tabs: s.tabs.map((current) =>
+            current.id === owner.id && isTerminal(current)
+              ? { ...current, activePaneId: id }
+              : current,
+          ),
+          activeId: owner.id,
+          lastPaneId: id,
         };
       }),
 
@@ -382,37 +576,29 @@ export const useTabsStore = create<TabsState>((set, get) => {
       setActive(next.id);
     },
 
-    setTerminalStatus: (id, status, error, errorCode) =>
-      set((s) => ({
-        tabs: s.tabs.map((t) =>
-          t.id === id && isTerminal(t) ? { ...t, status, error, errorCode } : t,
-        ),
-      })),
+    setTerminalStatus: (paneId, status, error, errorCode) =>
+      patchPane(paneId, { status, error, errorCode }),
 
-    reconnectTerminal: (id) =>
-      set((s) => ({
-        tabs: s.tabs.map((t) =>
-          t.id === id && isTerminal(t)
-            ? {
-                ...t,
-                status: "connecting" as const,
-                error: undefined,
-                errorCode: undefined,
-                attempt: t.attempt + 1,
-              }
-            : t,
-        ),
-      })),
+    reconnectTerminal: (paneId) => {
+      const pane = findPane(get().tabs, paneId);
+      if (!pane) return;
+      patchPane(paneId, {
+        status: "connecting",
+        error: undefined,
+        errorCode: undefined,
+        attempt: pane.attempt + 1,
+      });
+    },
 
     sendToTerminal: (command) => {
-      const id = targetTerminalId(get());
-      const tab = findOpenTerminal(get().tabs, id);
+      const id = targetPaneId(get());
+      const pane = findPane(get().tabs, id);
       const session = getSession(id);
-      if (!id || !tab || !session) return "no-terminal";
-      if (tab.status !== "connected") return "not-connected";
+      if (!id || !pane || !session) return "no-terminal";
+      if (pane.status !== "connected") return "not-connected";
       session.sendCommand(command);
       void ipc.history
-        .add(tab.target === "ssh" ? tab.hostId : null, command)
+        .add(pane.target === "ssh" ? pane.hostId : null, command)
         .catch(() => {});
       get().setActive(id);
       return "sent";


### PR DESCRIPTION
Implements the terminal split-pane feature requested in #24 (part one: splitting terminal sessions).

## Features

- Split panes right / down within a terminal tab; each pane is an independent terminal session that reuses the source pane's connection target
- Layout is a recursive tree (`pane-layout.ts`) supporting nested row/column mixes, capped at 3 columns × 2 rows with a toast warning on overflow
- Panes are resizable via drag or keyboard (90px minimum); the global session cap of 10 still applies
- Right-click context menu: copy, paste, select all, clear, split, close pane
- Shortcuts: `⌘\` split right, `⌘⇧\` split down, `⌘[` / `⌘]` cycle panes, `⌘W` closes the focused pane first; all registered in the command palette
- Tab strip shows the active pane's title plus a pane-count badge; status overlay, sticky command header, and search bar all operate per pane
- AI tools, input broadcasting, monitor view, and status bar migrated to pane granularity (`list_terminal_sessions` annotates panes as `1/2`)
- Tauri clipboard capability narrowed to `allow-read-text` / `allow-write-text`

## Notes

- The file-editor split view mentioned in #24 is out of scope for this PR and can be a follow-up iteration
- Adds `pane-layout` unit tests and tabs-store split behavior tests (332 tests passing)
- typecheck / lint / prettier / conventions / bundle budget (700.4 kB < 701 kB) all pass
