### PR TITLE
feat(app): hide to tray on close so scheduled tasks keep running

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6301,6 +6301,7 @@ dependencies = [
  "gtk",
  "heck 0.5.0",
  "http",
+ "image",
  "jni 0.21.1",
  "libc",
  "log",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -18,7 +18,7 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
-tauri = { version = "2", features = [] }
+tauri = { version = "2", features = ["tray-icon", "image-png"] }
 tauri-plugin-opener = "2"
 tauri-plugin-os = "2"
 tauri-plugin-dialog = "2"
@@ -73,14 +73,17 @@ objc2 = "0.6"
 block2 = "0.6"
 objc2-app-kit = { version = "0.3", default-features = false, features = [
   "std",
+  "NSApplication",
   "NSButton",
   "NSControl",
+  "NSImage",
   "NSResponder",
   "NSView",
   "NSWindow",
 ] }
 objc2-foundation = { version = "0.3", default-features = false, features = [
   "std",
+  "NSData",
   "NSNotification",
   "NSObject",
   "NSOperation",

--- a/src-tauri/src/commands/tasks.rs
+++ b/src-tauri/src/commands/tasks.rs
@@ -10,8 +10,8 @@ use tokio::task::JoinSet;
 
 use crate::domain::{Task, TaskInput, TaskStep};
 use crate::error::{AppError, AppResult};
-use crate::repository::task_run_repo::{self, TaskRunRow};
 use crate::repository::task_repo;
+use crate::repository::task_run_repo::{self, TaskRunRow};
 use crate::sftp::path::{parent_remote, sh_quote};
 use crate::sftp::{self, base_name, Endpoint, SftpConnectParams, TransferCancel, TransferRequest};
 use crate::state::AppState;
@@ -359,8 +359,10 @@ async fn run_all(
         connect_task_session(app, state, &conn_id, host.label, hops, cancel).await?;
     }
 
-    let result =
-        execute_steps(app, state, &conn_id, steps, request_id, cancel, on_event, outcomes).await;
+    let result = execute_steps(
+        app, state, &conn_id, steps, request_id, cancel, on_event, outcomes,
+    )
+    .await;
 
     if needs_remote {
         state.sftp.disconnect(app, &conn_id);

--- a/src-tauri/src/commands/window.rs
+++ b/src-tauri/src/commands/window.rs
@@ -48,6 +48,17 @@ pub fn window_set_traffic_light_inset(window: tauri::Window, x: f64, height: f64
     Ok(())
 }
 
+/// Hide the window to the tray instead of closing it. The frontend close button
+/// calls this rather than `window.close()`, because destroying the only window
+/// would tear down the webview (and its task scheduler); hiding keeps it alive.
+#[tauri::command]
+pub fn window_hide_to_tray(window: tauri::Window) {
+    #[cfg(desktop)]
+    crate::tray::hide_main_window(&window);
+    #[cfg(not(desktop))]
+    let _ = window;
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src-tauri/src/domain/task.rs
+++ b/src-tauri/src/domain/task.rs
@@ -58,8 +58,6 @@ pub enum TaskStep {
         local_path: String,
         remote_path: String,
         #[serde(default)]
-        incremental: bool,
-        #[serde(default)]
         retries: u32,
     },
     Download {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -14,6 +14,8 @@ mod ssh;
 mod sshkey;
 mod state;
 mod sync;
+#[cfg(desktop)]
+mod tray;
 mod update;
 
 use tauri::webview::PageLoadEvent;
@@ -78,14 +80,31 @@ pub fn run() {
     #[cfg(desktop)]
     let builder = builder
         .plugin(tauri_plugin_single_instance::init(|app, _, _| {
-            if let Some(window) = app.get_webview_window("main") {
-                let _ = window.unminimize();
-                let _ = window.show();
-                let _ = window.set_focus();
-            }
+            tray::show_main_window(app);
         }))
         .plugin(tauri_plugin_autostart::Builder::new().build());
     let app = builder
+        .on_window_event(|window, event| {
+            // Closing the window hides it to the tray so the in-webview task
+            // scheduler keeps running; quitting is only reachable from the tray
+            // menu. The frontend owns the hide (Workbench's onCloseRequested
+            // must preventDefault, or the JS API destroys the webview); this is
+            // a safety net for close requests the frontend cannot answer.
+            // prevent_close() must stay the only synchronous action: hiding or
+            // switching activation policy inside the native close cycle lets
+            // macOS destroy the window despite the prevent signal.
+            #[cfg(desktop)]
+            if let tauri::WindowEvent::CloseRequested { api, .. } = event {
+                api.prevent_close();
+                let window = window.clone();
+                tauri::async_runtime::spawn(async move {
+                    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                    tray::hide_main_window(&window);
+                });
+            }
+            #[cfg(not(desktop))]
+            let _ = (window, event);
+        })
         .on_page_load(|webview, payload| {
             if payload.event() == PageLoadEvent::Started {
                 if let Some(state) = webview.try_state::<AppState>() {
@@ -115,6 +134,9 @@ pub fn run() {
             if let Some(window) = app.get_webview_window("main") {
                 commands::window::preset_traffic_light_inset(&window);
             }
+
+            #[cfg(desktop)]
+            tray::build(app.handle())?;
 
             let handle = app.handle().clone();
             tauri::async_runtime::spawn(update::run_periodic(handle));
@@ -228,6 +250,7 @@ pub fn run() {
             commands::sync::sync_file_import,
             commands::app::app_is_portable,
             commands::window::window_set_traffic_light_inset,
+            commands::window::window_hide_to_tray,
             commands::update::update_status,
             commands::update::update_can_self_update,
             commands::update::update_check,
@@ -249,12 +272,21 @@ pub fn run() {
         .build(tauri::generate_context!())
         .expect("error while building tauri application");
 
-    app.run(|handle, event| {
-        if matches!(event, tauri::RunEvent::Exit) {
+    app.run(|handle, event| match event {
+        tauri::RunEvent::ExitRequested { code, api, .. } => {
+            // `None` = user interaction (last window closed / OS quit): stay alive
+            // in the tray so the task scheduler keeps running. `Some` = explicit
+            // `app.exit()`/`restart()` (tray Quit, updater): let it proceed.
+            if code.is_none() {
+                api.prevent_exit();
+            }
+        }
+        tauri::RunEvent::Exit => {
             if let Some(state) = handle.try_state::<AppState>() {
                 cleanup_orphaned_sessions(&state);
             }
         }
+        _ => {}
     });
 }
 

--- a/src-tauri/src/repository/task_repo.rs
+++ b/src-tauri/src/repository/task_repo.rs
@@ -88,7 +88,6 @@ fn normalize_step(step: TaskStep) -> AppResult<TaskStep> {
         TaskStep::Upload {
             local_path,
             remote_path,
-            incremental,
             retries,
         } => {
             let local_path = local_path.trim().to_string();
@@ -108,7 +107,6 @@ fn normalize_step(step: TaskStep) -> AppResult<TaskStep> {
             TaskStep::Upload {
                 local_path,
                 remote_path,
-                incremental,
                 retries: retries.min(MAX_RETRIES),
             }
         }
@@ -313,7 +311,6 @@ mod tests {
                 TaskStep::Upload {
                     local_path: "  ./dist  ".into(),
                     remote_path: "  /var/www/app  ".into(),
-                    incremental: true,
                     retries: 0,
                 },
             ],

--- a/src-tauri/src/repository/task_run_repo.rs
+++ b/src-tauri/src/repository/task_run_repo.rs
@@ -163,9 +163,18 @@ mod tests {
     #[tokio::test]
     async fn records_finishes_and_prunes_history() {
         let pool = test_pool().await;
-        create(&pool, "run-1", "task-1", "Deploy", Some("host-1"), Some("web-01"), "[]", 2)
-            .await
-            .unwrap();
+        create(
+            &pool,
+            "run-1",
+            "task-1",
+            "Deploy",
+            Some("host-1"),
+            Some("web-01"),
+            "[]",
+            2,
+        )
+        .await
+        .unwrap();
         finish(&pool, "run-1", "done", None, "[{\"status\":\"done\"}]")
             .await
             .unwrap();

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -1,0 +1,106 @@
+use tauri::image::Image;
+use tauri::menu::{Menu, MenuItem};
+use tauri::tray::{MouseButton, TrayIconBuilder, TrayIconEvent};
+use tauri::{AppHandle, Manager};
+
+use crate::repository::settings_repo;
+use crate::state::AppState;
+
+/// Bundled PNG for the menu-bar icon. Embedded explicitly rather than reusing
+/// `default_window_icon()`, which is `None` in dev builds and would leave a
+/// zero-width, unclickable status item on macOS.
+const TRAY_ICON: &[u8] = include_bytes!("../icons/32x32.png");
+
+/// Bring the main window back to the foreground and, on macOS, restore the dock
+/// icon that hide-to-tray removed. Shared by the tray icon, the tray menu, and
+/// the single-instance relaunch handler so every "reopen" path behaves the same.
+pub fn show_main_window(app: &AppHandle) {
+    #[cfg(target_os = "macos")]
+    {
+        let _ = app.set_activation_policy(tauri::ActivationPolicy::Regular);
+        #[cfg(debug_assertions)]
+        reapply_dev_dock_icon();
+    }
+    if let Some(window) = app.get_webview_window("main") {
+        let _ = window.unminimize();
+        let _ = window.show();
+        let _ = window.set_focus();
+    }
+}
+
+/// Dev builds run a bare binary with no .app bundle, so coming back from
+/// Accessory re-creates the dock tile with the generic "exec" icon. Re-apply
+/// the bundled icon the same way Tauri does on startup. Packaged builds take
+/// the icon from the bundle and don't need this.
+#[cfg(all(debug_assertions, target_os = "macos"))]
+fn reapply_dev_dock_icon() {
+    use objc2::{AllocAnyThread, MainThreadMarker};
+    use objc2_app_kit::{NSApplication, NSImage};
+    use objc2_foundation::NSData;
+
+    const DOCK_ICON: &[u8] = include_bytes!("../icons/128x128@2x.png");
+    let Some(mtm) = MainThreadMarker::new() else {
+        return;
+    };
+    let data = NSData::with_bytes(DOCK_ICON);
+    if let Some(icon) = NSImage::initWithData(NSImage::alloc(), &data) {
+        unsafe { NSApplication::sharedApplication(mtm).setApplicationIconImage(Some(&icon)) };
+    }
+}
+
+/// Hide the main window instead of destroying it so the in-webview task
+/// scheduler keeps ticking in the background. On macOS also drop to Accessory so
+/// the app leaves the dock and lives only in the menu bar.
+pub fn hide_main_window(window: &tauri::Window) {
+    let _ = window.hide();
+    #[cfg(target_os = "macos")]
+    let _ = window
+        .app_handle()
+        .set_activation_policy(tauri::ActivationPolicy::Accessory);
+}
+
+/// Pick tray labels from the persisted UI language. The tray is built once at
+/// startup, so switching language in-app only relabels it after a restart.
+fn prefers_zh(app: &AppHandle) -> bool {
+    let state = app.state::<AppState>();
+    tauri::async_runtime::block_on(settings_repo::get(&state.db, "general.locale"))
+        .ok()
+        .flatten()
+        .is_some_and(|value| value.starts_with("zh"))
+}
+
+/// Install the menu-bar / system-tray icon: a click opens the menu with Show and
+/// Quit, and double-click reveals the window. Quit is the only path that exits.
+pub fn build(app: &AppHandle) -> tauri::Result<()> {
+    let (show_label, quit_label) = if prefers_zh(app) {
+        ("显示 Sageport", "退出 Sageport")
+    } else {
+        ("Show Sageport", "Quit Sageport")
+    };
+    let show_item = MenuItem::with_id(app, "tray-show", show_label, true, None::<&str>)?;
+    let quit_item = MenuItem::with_id(app, "tray-quit", quit_label, true, None::<&str>)?;
+    let menu = Menu::with_items(app, &[&show_item, &quit_item])?;
+
+    TrayIconBuilder::with_id("main")
+        .icon(Image::from_bytes(TRAY_ICON)?)
+        .tooltip("Sageport")
+        .menu(&menu)
+        .show_menu_on_left_click(true)
+        .on_menu_event(|app, event| match event.id.as_ref() {
+            "tray-show" => show_main_window(app),
+            "tray-quit" => app.exit(0),
+            _ => {}
+        })
+        .on_tray_icon_event(|tray, event| {
+            if let TrayIconEvent::DoubleClick {
+                button: MouseButton::Left,
+                ..
+            } = event
+            {
+                show_main_window(tray.app_handle());
+            }
+        })
+        .build(app)?;
+
+    Ok(())
+}

--- a/src/features/ai/tools/tasks.test.ts
+++ b/src/features/ai/tools/tasks.test.ts
@@ -112,7 +112,9 @@ describe("list_tasks", () => {
   });
 });
 
-function runEntry(overrides: Partial<TaskRunHistoryEntry>): TaskRunHistoryEntry {
+function runEntry(
+  overrides: Partial<TaskRunHistoryEntry>,
+): TaskRunHistoryEntry {
   return {
     id: "r1",
     taskId: "t1",

--- a/src/features/ai/tools/tasks.test.ts
+++ b/src/features/ai/tools/tasks.test.ts
@@ -4,6 +4,7 @@ const mocks = vi.hoisted(() => ({
   create: vi.fn(),
   update: vi.fn(),
   list: vi.fn(),
+  runsList: vi.fn(),
 }));
 
 vi.mock("@/lib/ipc", () => ({
@@ -12,13 +13,14 @@ vi.mock("@/lib/ipc", () => ({
       create: mocks.create,
       update: mocks.update,
       list: mocks.list,
+      runsList: mocks.runsList,
     },
   },
 }));
 
 vi.mock("./cache", () => ({ invalidateTasks: vi.fn() }));
 
-import type { Task, TaskInput } from "@/types/models";
+import type { Task, TaskInput, TaskRunHistoryEntry } from "@/types/models";
 import { taskTools } from "./tasks";
 
 function tool(name: string) {
@@ -107,5 +109,57 @@ describe("list_tasks", () => {
     expect(parsed[0].schedule).toBe("0 3 * * *");
     expect(parsed[0].scheduleEnabled).toBe(true);
     expect(typeof parsed[0].nextRun).toBe("string");
+  });
+});
+
+function runEntry(overrides: Partial<TaskRunHistoryEntry>): TaskRunHistoryEntry {
+  return {
+    id: "r1",
+    taskId: "t1",
+    taskName: "Backup",
+    hostId: null,
+    hostLabel: null,
+    steps: JSON.stringify([
+      { step: { type: "localCommand", command: "echo hi" }, status: "done" },
+    ]),
+    totalSteps: 1,
+    status: "done",
+    message: null,
+    startedAt: "2026-07-24T03:00:00.000Z",
+    finishedAt: "2026-07-24T03:00:01.000Z",
+    ...overrides,
+  };
+}
+
+describe("list_task_runs", () => {
+  it("summarizes runs with per-step outcomes", async () => {
+    mocks.runsList.mockResolvedValue([runEntry({})]);
+    const result = await tool("list_task_runs")({}, {});
+    const parsed = JSON.parse(result.content) as Array<{
+      id: string;
+      status: string;
+      steps: string[];
+    }>;
+    expect(parsed[0].id).toBe("r1");
+    expect(parsed[0].status).toBe("done");
+    expect(parsed[0].steps[0]).toContain("done");
+  });
+
+  it("filters by taskId and respects the limit", async () => {
+    mocks.runsList.mockResolvedValue([
+      runEntry({ id: "r1", taskId: "t1" }),
+      runEntry({ id: "r2", taskId: "t2" }),
+      runEntry({ id: "r3", taskId: "t1" }),
+    ]);
+    const result = await tool("list_task_runs")({ taskId: "t1", limit: 1 }, {});
+    const parsed = JSON.parse(result.content) as Array<{ id: string }>;
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0].id).toBe("r1");
+  });
+
+  it("reports when a task has no runs", async () => {
+    mocks.runsList.mockResolvedValue([runEntry({ taskId: "other" })]);
+    const result = await tool("list_task_runs")({ taskId: "t1" }, {});
+    expect(result.content).toContain("No runs recorded");
   });
 });

--- a/src/features/ai/tools/tasks.ts
+++ b/src/features/ai/tools/tasks.ts
@@ -1,4 +1,11 @@
-import { History, ListChecks, Play, Save, SquarePen, Trash2 } from "lucide-react";
+import {
+  History,
+  ListChecks,
+  Play,
+  Save,
+  SquarePen,
+  Trash2,
+} from "lucide-react";
 
 import { parseTaskSteps } from "@/features/tasks/api";
 import { taskNeedsRemote } from "@/features/tasks/steps";

--- a/src/features/ai/tools/tasks.ts
+++ b/src/features/ai/tools/tasks.ts
@@ -1,14 +1,21 @@
-import { ListChecks, Play, Save, SquarePen, Trash2 } from "lucide-react";
+import { History, ListChecks, Play, Save, SquarePen, Trash2 } from "lucide-react";
 
 import { parseTaskSteps } from "@/features/tasks/api";
 import { taskNeedsRemote } from "@/features/tasks/steps";
 import { useTaskRunStore, type TaskRun } from "@/features/tasks/store";
 import { isValidCron, nextCronTime } from "@/lib/cron";
 import { ipc } from "@/lib/ipc";
-import type { Task, TaskInput, TaskStep } from "@/types/models";
+import type {
+  Task,
+  TaskInput,
+  TaskRunHistoryEntry,
+  TaskRunStepRecord,
+  TaskStep,
+} from "@/types/models";
 import { invalidateTasks } from "./cache";
 import {
   bool,
+  num,
   nullableStr,
   optionalStr,
   str,
@@ -137,6 +144,61 @@ async function listTasks(): Promise<ToolExecutionResult> {
         };
       }),
     ),
+  );
+}
+
+function parseRunSteps(steps: string): TaskRunStepRecord[] {
+  try {
+    const parsed = JSON.parse(steps);
+    return Array.isArray(parsed) ? (parsed as TaskRunStepRecord[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+function summarizeRunEntry(entry: TaskRunHistoryEntry) {
+  const steps = parseRunSteps(entry.steps).map((record, index) => {
+    const exit =
+      record.exitCode !== undefined && record.exitCode !== 0
+        ? ` (exit ${record.exitCode})`
+        : "";
+    return `${index + 1}. ${STEP_LABEL[record.step.type]} — ${record.status}${exit}`;
+  });
+  return {
+    id: entry.id,
+    taskId: entry.taskId,
+    taskName: entry.taskName,
+    host: entry.hostLabel ?? undefined,
+    status: entry.status,
+    startedAt: entry.startedAt,
+    finishedAt: entry.finishedAt ?? undefined,
+    message: entry.message ?? undefined,
+    steps,
+  };
+}
+
+async function listTaskRuns(
+  args: Record<string, unknown>,
+): Promise<ToolExecutionResult> {
+  const taskId = optionalStr(args, "taskId");
+  const requested = num(args, "limit");
+  const limit =
+    requested !== undefined
+      ? Math.min(Math.max(1, Math.trunc(requested)), 100)
+      : 20;
+  const entries = await ipc.tasks.runsList();
+  const filtered = taskId
+    ? entries.filter((entry) => entry.taskId === taskId)
+    : entries;
+  if (filtered.length === 0) {
+    return toolSuccess(
+      taskId
+        ? `No runs recorded for task "${taskId}" yet.`
+        : "No task runs recorded yet.",
+    );
+  }
+  return toolSuccess(
+    JSON.stringify(filtered.slice(0, limit).map(summarizeRunEntry)),
   );
 }
 
@@ -273,6 +335,7 @@ const STEP_SCHEMA = {
     "{type:'upload', localPath, remotePath, retries?}; " +
     "{type:'download', remotePath, localPath, retries?}. " +
     "retries (default 0, max 10) is how many extra attempts to make if the step fails. " +
+    "Commands are limited to 32000 characters and paths to 4000. " +
     "All commands and paths are literal; there are no runtime variables.",
 } as const;
 
@@ -301,9 +364,33 @@ export const taskTools: AiTool[] = [
   },
   {
     spec: {
+      name: "list_task_runs",
+      description:
+        "List the history of past task runs, most recent first, with each run's overall status, host, start/finish times, any failure message, and per-step outcomes. Pass taskId to see only one task's runs.",
+      parameters: {
+        type: "object",
+        properties: {
+          taskId: {
+            type: "string",
+            description: "Only list runs of this task id (from list_tasks).",
+          },
+          limit: {
+            type: "number",
+            description: "Max runs to return (default 20, max 100).",
+          },
+        },
+        additionalProperties: false,
+      },
+    },
+    icon: History,
+    labelKey: "ai.tool.listTaskRuns",
+    execute: async (args) => listTaskRuns(args),
+  },
+  {
+    spec: {
       name: "run_task",
       description:
-        "Run a saved task on its fixed host: it executes its ordered steps (local commands, uploads, downloads, remote commands), retrying a step up to its configured retries, and stops the run once a step still fails after its retries. A task with remote steps must already have a fixed host. Always requires user approval.",
+        "Run a saved task: it executes its ordered steps (local commands, uploads, downloads, remote commands), retrying a step up to its configured retries, and stops the run once a step still fails after its retries. A task with remote steps runs on its fixed host and must already have one set; a local-only task runs on this machine. Always requires user approval.",
       parameters: {
         type: "object",
         properties: {
@@ -330,8 +417,14 @@ export const taskTools: AiTool[] = [
       parameters: {
         type: "object",
         properties: {
-          name: { type: "string", description: "Task name." },
-          description: { type: "string", description: "Optional description." },
+          name: {
+            type: "string",
+            description: "Task name (up to 255 characters).",
+          },
+          description: {
+            type: "string",
+            description: "Optional description (up to 4000 characters).",
+          },
           hostId: {
             type: "string",
             description:

--- a/src/features/tasks/TaskFormDialog.tsx
+++ b/src/features/tasks/TaskFormDialog.tsx
@@ -186,6 +186,7 @@ function TaskFormBody({
     task?.scheduleEnabled ?? false,
   );
   const [schedule, setSchedule] = useState(task?.schedule ?? "");
+  const [openStepIndex, setOpenStepIndex] = useState<number | null>(null);
 
   const needsHost = useMemo(() => taskNeedsRemote(steps), [steps]);
 
@@ -204,8 +205,10 @@ function TaskFormBody({
       return next;
     });
 
-  const addStep = (type: (typeof STEP_TYPES)[number]) =>
+  const addStep = (type: (typeof STEP_TYPES)[number]) => {
+    setOpenStepIndex(steps.length);
     setSteps((prev) => [...prev, newStep(type)]);
+  };
 
   const submit = async () => {
     if (!name.trim()) return toast.error(t("tasks.form.nameRequired"));
@@ -289,6 +292,7 @@ function TaskFormBody({
 
       <StepsSection
         steps={steps}
+        openIndex={openStepIndex}
         onAdd={addStep}
         onChange={updateStep}
         onRemove={removeStep}
@@ -300,12 +304,14 @@ function TaskFormBody({
 
 function StepsSection({
   steps,
+  openIndex,
   onAdd,
   onChange,
   onRemove,
   onMove,
 }: {
   steps: TaskStep[];
+  openIndex: number | null;
   onAdd: (type: TaskStepType) => void;
   onChange: (index: number, step: TaskStep) => void;
   onRemove: (index: number) => void;
@@ -314,10 +320,10 @@ function StepsSection({
   const { t } = useI18n();
 
   return (
-    <div className="flex flex-col gap-2">
+    <div className="flex flex-col gap-1.5">
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-1.5">
-          <span className="text-xs font-medium text-muted-foreground">
+          <span className="text-sm font-medium text-foreground">
             {t("tasks.form.steps")}
           </span>
           <span className="flex h-4 min-w-4 items-center justify-center rounded-full bg-muted px-1 text-2xs tabular-nums text-muted-foreground">
@@ -344,19 +350,22 @@ function StepsSection({
         </DropdownMenu>
       </div>
 
-      <div className="flex flex-col gap-2">
-        {steps.map((step, index) => (
-          <TaskStepCard
-            key={index}
-            step={step}
-            index={index}
-            total={steps.length}
-            onChange={(next) => onChange(index, next)}
-            onRemove={() => onRemove(index)}
-            onMove={(direction) => onMove(index, direction)}
-          />
-        ))}
-      </div>
+      {steps.length > 0 && (
+        <div className="divide-y divide-border overflow-hidden rounded-lg border border-border bg-surface">
+          {steps.map((step, index) => (
+            <TaskStepCard
+              key={index}
+              step={step}
+              index={index}
+              total={steps.length}
+              defaultOpen={index === openIndex}
+              onChange={(next) => onChange(index, next)}
+              onRemove={() => onRemove(index)}
+              onMove={(direction) => onMove(index, direction)}
+            />
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/features/tasks/TaskRunHistoryDialog.tsx
+++ b/src/features/tasks/TaskRunHistoryDialog.tsx
@@ -127,7 +127,9 @@ export function TaskRunHistoryDialog({
           )}
 
           {isError && (
-            <p className="text-sm text-danger">{t("tasks.history.loadError")}</p>
+            <p className="text-sm text-danger">
+              {t("tasks.history.loadError")}
+            </p>
           )}
 
           {!isLoading && !isError && entries?.length === 0 && (
@@ -210,12 +212,17 @@ function RunRow({
             </div>
             <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5 text-xs text-muted-foreground">
               {entry.hostLabel && (
-                <span className="flex items-center gap-1" title={entry.hostLabel}>
+                <span
+                  className="flex items-center gap-1"
+                  title={entry.hostLabel}
+                >
                   <Server className="size-3 shrink-0" />
                   {entry.hostLabel}
                 </span>
               )}
-              <span>{t("tasks.history.steps", { count: entry.totalSteps })}</span>
+              <span>
+                {t("tasks.history.steps", { count: entry.totalSteps })}
+              </span>
               <span>·</span>
               <span>{new Date(entry.startedAt).toLocaleString()}</span>
               {duration && (
@@ -281,7 +288,9 @@ function StepStatusIcon({ status }: { status: TaskRunStepStatus }) {
     case "error":
       return <XCircle className="size-3.5 shrink-0 text-danger" />;
     case "skipped":
-      return <CircleSlash className="size-3.5 shrink-0 text-muted-foreground" />;
+      return (
+        <CircleSlash className="size-3.5 shrink-0 text-muted-foreground" />
+      );
     default:
       return <Clock3 className="size-3.5 shrink-0 text-muted-foreground" />;
   }
@@ -290,7 +299,8 @@ function StepStatusIcon({ status }: { status: TaskRunStepStatus }) {
 /** Human-readable run duration, or null when it never finished. */
 function runDuration(entry: TaskRunHistoryEntry): string | null {
   if (!entry.finishedAt) return null;
-  const ms = new Date(entry.finishedAt).getTime() - new Date(entry.startedAt).getTime();
+  const ms =
+    new Date(entry.finishedAt).getTime() - new Date(entry.startedAt).getTime();
   if (!Number.isFinite(ms) || ms < 0) return null;
   if (ms < 1000) return `${Math.round(ms)}ms`;
   const seconds = ms / 1000;

--- a/src/features/tasks/TaskScheduleField.tsx
+++ b/src/features/tasks/TaskScheduleField.tsx
@@ -42,51 +42,59 @@ export function TaskScheduleField({
   }, [schedule, t]);
 
   return (
-    <div className="flex flex-col gap-2">
-      <SwitchField
-        label={t("tasks.schedule.enable")}
-        description={t("tasks.schedule.enableHint")}
-        checked={enabled}
-        onCheckedChange={onEnabledChange}
-      />
-      {enabled && (
-        <div className="flex flex-col gap-2">
-          <div className="flex flex-wrap gap-1.5">
-            {CRON_PRESETS.map((preset) => (
-              <button
-                key={preset.id}
-                type="button"
-                onClick={() => onScheduleChange(preset.expr)}
-                data-active={schedule.trim() === preset.expr}
+    <div className="flex flex-col gap-1.5">
+      <span className="text-sm font-medium text-foreground">
+        {t("tasks.schedule.label")}
+      </span>
+      <div className="flex flex-col gap-2">
+        <SwitchField
+          label={t("tasks.schedule.enable")}
+          description={t("tasks.schedule.enableHint")}
+          checked={enabled}
+          onCheckedChange={(next) => {
+            onEnabledChange(next);
+            if (!next) onScheduleChange("");
+          }}
+        />
+        {enabled && (
+          <div className="flex flex-col gap-2">
+            <div className="flex flex-wrap gap-1.5">
+              {CRON_PRESETS.map((preset) => (
+                <button
+                  key={preset.id}
+                  type="button"
+                  onClick={() => onScheduleChange(preset.expr)}
+                  data-active={schedule.trim() === preset.expr}
+                  className={cn(
+                    INTERACTIVE_FOCUS_CLASS,
+                    "rounded-md border border-border bg-surface px-2 py-1 text-2xs text-muted-foreground transition-colors hover:border-ring/60 hover:bg-list-hover data-[active=true]:border-primary/40 data-[active=true]:bg-primary/10 data-[active=true]:text-link",
+                  )}
+                >
+                  {t(PRESET_LABELS[preset.id])}
+                </button>
+              ))}
+            </div>
+            <Input
+              value={schedule}
+              onChange={(e) => onScheduleChange(e.target.value)}
+              placeholder={t("tasks.schedule.cronPlaceholder")}
+              spellCheck={false}
+              className="font-mono"
+              maxLength={256}
+            />
+            {hint && (
+              <span
                 className={cn(
-                  INTERACTIVE_FOCUS_CLASS,
-                  "rounded-md border border-border bg-surface px-2 py-1 text-2xs text-muted-foreground transition-colors hover:border-ring/60 hover:bg-list-hover data-[active=true]:border-primary/40 data-[active=true]:bg-primary/10 data-[active=true]:text-link",
+                  "text-2xs",
+                  hint.error ? "text-danger" : "text-muted-foreground",
                 )}
               >
-                {t(PRESET_LABELS[preset.id])}
-              </button>
-            ))}
+                {hint.text}
+              </span>
+            )}
           </div>
-          <Input
-            value={schedule}
-            onChange={(e) => onScheduleChange(e.target.value)}
-            placeholder={t("tasks.schedule.cronPlaceholder")}
-            spellCheck={false}
-            className="font-mono"
-            maxLength={256}
-          />
-          {hint && (
-            <span
-              className={cn(
-                "text-2xs",
-                hint.error ? "text-danger" : "text-muted-foreground",
-              )}
-            >
-              {hint.text}
-            </span>
-          )}
-        </div>
-      )}
+        )}
+      </div>
     </div>
   );
 }

--- a/src/features/tasks/TaskStepCard.tsx
+++ b/src/features/tasks/TaskStepCard.tsx
@@ -1,22 +1,27 @@
-import {
-  ChevronDown,
-  ChevronUp,
-  Minus,
-  MonitorSmartphone,
-  Plus,
-  X,
-} from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { ChevronDown, ChevronUp, Minus, Plus, X } from "lucide-react";
 
-import { Button, Field, Input, Textarea, Tooltip } from "@/components/ui";
+import {
+  Button,
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+  Field,
+  Input,
+  INTERACTIVE_FOCUS_CLASS,
+  Textarea,
+  Tooltip,
+} from "@/components/ui";
 import { useI18n } from "@/i18n";
 import { cn } from "@/lib/utils";
 import type { TaskStep } from "@/types/models";
-import { MAX_STEP_RETRIES, STEP_META } from "./steps";
+import { MAX_STEP_RETRIES, STEP_META, stepSummary } from "./steps";
 
 interface TaskStepCardProps {
   step: TaskStep;
   index: number;
   total: number;
+  defaultOpen?: boolean;
   disabled?: boolean;
   onChange: (step: TaskStep) => void;
   onRemove: () => void;
@@ -27,83 +32,112 @@ export function TaskStepCard({
   step,
   index,
   total,
+  defaultOpen = false,
   disabled,
   onChange,
   onRemove,
   onMove,
 }: TaskStepCardProps) {
   const { t } = useI18n();
+  const [open, setOpen] = useState(defaultOpen);
+  const cardRef = useRef<HTMLDivElement>(null);
   const meta = STEP_META[step.type];
   const Icon = meta.icon;
+  const summary = stepSummary(step);
+
+  useEffect(() => {
+    if (defaultOpen) {
+      cardRef.current?.scrollIntoView({ behavior: "smooth", block: "nearest" });
+    }
+  }, [defaultOpen]);
 
   return (
-    <div className="overflow-hidden rounded-lg border border-border bg-surface">
-      <div className="flex items-center gap-2 border-b border-border bg-surface/40 px-3 py-2">
-        <span className="flex size-5 shrink-0 items-center justify-center rounded-full bg-accent/15 text-2xs font-semibold text-accent">
-          {index + 1}
-        </span>
-        <Icon
-          className="size-4 shrink-0 text-muted-foreground"
-          strokeWidth={1.7}
-        />
-        <span className="min-w-0 flex-1 truncate text-sm font-medium">
-          {t(meta.labelKey)}
-        </span>
-        <Tooltip content={t("tasks.form.moveUp")}>
-          <Button
-            size="icon"
-            variant="ghost"
-            className="size-6"
-            disabled={disabled || index === 0}
-            onClick={() => onMove(-1)}
-          >
-            <ChevronUp className="size-3.5" />
-          </Button>
-        </Tooltip>
-        <Tooltip content={t("tasks.form.moveDown")}>
-          <Button
-            size="icon"
-            variant="ghost"
-            className="size-6"
-            disabled={disabled || index === total - 1}
-            onClick={() => onMove(1)}
-          >
-            <ChevronDown className="size-3.5" />
-          </Button>
-        </Tooltip>
-        <Tooltip content={t("tasks.form.removeStep")}>
-          <Button
-            size="icon"
-            variant="ghost"
-            className="size-6 text-muted-foreground hover:text-danger"
+    <Collapsible ref={cardRef} open={open} onOpenChange={setOpen}>
+      <div className="group flex items-center gap-1 px-2 py-1.5">
+        <CollapsibleTrigger asChild>
+          <button
+            type="button"
             disabled={disabled}
-            onClick={onRemove}
+            className={cn(
+              INTERACTIVE_FOCUS_CLASS,
+              "flex min-w-0 flex-1 items-center gap-2 rounded-md px-1 py-1",
+            )}
           >
-            <X className="size-3.5" />
-          </Button>
-        </Tooltip>
-      </div>
-
-      <div className="flex flex-col gap-3 p-3">
-        {step.type === "localCommand" && (
-          <div className="flex items-center gap-1.5 rounded-md bg-warning/10 px-2 py-1 text-2xs text-warning">
-            <MonitorSmartphone className="size-3.5 shrink-0" />
-            {t("tasks.step.localHint")}
-          </div>
-        )}
-
-        <StepFields step={step} disabled={disabled} onChange={onChange} />
-
-        <div className="flex items-center justify-between gap-2 text-xs text-muted-foreground">
-          <span>{t("tasks.form.retries")}</span>
-          <RetryStepper
-            value={step.retries ?? 0}
-            disabled={disabled}
-            onChange={(retries) => onChange({ ...step, retries })}
-          />
+            <ChevronDown
+              className={cn(
+                "size-3.5 shrink-0 text-muted-foreground transition-transform duration-200",
+                !open && "-rotate-90",
+              )}
+            />
+            <span className="flex size-5 shrink-0 items-center justify-center rounded-full border border-border text-2xs font-semibold text-muted-foreground">
+              {index + 1}
+            </span>
+            <Icon
+              className="size-4 shrink-0 text-muted-foreground"
+              strokeWidth={1.7}
+            />
+            <span className="shrink-0 text-sm font-medium">
+              {t(meta.labelKey)}
+            </span>
+            {!open && (
+              <span className="min-w-0 flex-1 truncate text-left font-mono text-2xs text-muted-foreground">
+                {summary}
+              </span>
+            )}
+          </button>
+        </CollapsibleTrigger>
+        <div className="flex items-center gap-1 opacity-0 transition-opacity focus-within:opacity-100 group-hover:opacity-100">
+          <Tooltip content={t("tasks.form.moveUp")}>
+            <Button
+              size="icon"
+              variant="ghost"
+              className="size-6"
+              disabled={disabled || index === 0}
+              onClick={() => onMove(-1)}
+            >
+              <ChevronUp className="size-3.5" />
+            </Button>
+          </Tooltip>
+          <Tooltip content={t("tasks.form.moveDown")}>
+            <Button
+              size="icon"
+              variant="ghost"
+              className="size-6"
+              disabled={disabled || index === total - 1}
+              onClick={() => onMove(1)}
+            >
+              <ChevronDown className="size-3.5" />
+            </Button>
+          </Tooltip>
+          <Tooltip content={t("tasks.form.removeStep")}>
+            <Button
+              size="icon"
+              variant="ghost"
+              className="size-6 text-muted-foreground hover:text-danger"
+              disabled={disabled}
+              onClick={onRemove}
+            >
+              <X className="size-3.5" />
+            </Button>
+          </Tooltip>
         </div>
       </div>
-    </div>
+
+      <CollapsibleContent>
+        <div className="flex flex-col gap-3 border-t border-border p-3">
+          <StepFields step={step} disabled={disabled} onChange={onChange} />
+
+          <div className="flex items-center justify-between gap-2 text-xs text-muted-foreground">
+            <span>{t("tasks.form.retries")}</span>
+            <RetryStepper
+              value={step.retries ?? 0}
+              disabled={disabled}
+              onChange={(retries) => onChange({ ...step, retries })}
+            />
+          </div>
+        </div>
+      </CollapsibleContent>
+    </Collapsible>
   );
 }
 

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -643,7 +643,6 @@ export const en = {
       remoteCommand: "Remote command",
       upload: "Upload",
       download: "Download",
-      localHint: "Runs on this machine",
     },
     template: {
       frontendDeploy: {
@@ -1004,6 +1003,7 @@ export const en = {
       updateSnippet: "Update snippet",
       deleteSnippet: "Delete snippet",
       listTasks: "List tasks",
+      listTaskRuns: "List task runs",
       runTask: "Run task",
       saveTask: "Save task",
       updateTask: "Update task",

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -624,7 +624,6 @@ export const zhCN: Dictionary = {
       remoteCommand: "远程命令",
       upload: "上传",
       download: "下载",
-      localHint: "在本机运行",
     },
     template: {
       frontendDeploy: {
@@ -973,6 +972,7 @@ export const zhCN: Dictionary = {
       updateSnippet: "更新命令片段",
       deleteSnippet: "删除命令片段",
       listTasks: "列出任务",
+      listTaskRuns: "列出运行记录",
       runTask: "运行任务",
       saveTask: "保存任务",
       updateTask: "更新任务",

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -515,6 +515,7 @@ export const ipc = {
   window: {
     setTrafficLightInset: (x: number, height: number) =>
       invoke<void>("window_set_traffic_light_inset", { x, height }),
+    hideToTray: () => invoke<void>("window_hide_to_tray"),
   },
   update: {
     status: () => invoke<UpdateStatus>("update_status"),

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -268,7 +268,6 @@ export type TaskStep =
       type: "upload";
       localPath: string;
       remotePath: string;
-      incremental?: boolean;
       retries?: number;
     }
   | {

--- a/src/workbench/WindowControls.tsx
+++ b/src/workbench/WindowControls.tsx
@@ -3,6 +3,7 @@ import { Copy, Minus, Square, X } from "lucide-react";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 
 import { useI18n } from "@/i18n";
+import { ipc } from "@/lib/ipc";
 import { errorMessage, toast } from "@/lib/toast";
 import { cn } from "@/lib/utils";
 import { installWindowListener } from "./window-listener";
@@ -79,7 +80,7 @@ export function WindowControls() {
           buttonClass,
           "hover:bg-destructive hover:text-destructive-foreground",
         )}
-        onClick={() => run(() => appWindow.close())}
+        onClick={() => run(() => ipc.window.hideToTray())}
       >
         <X className="size-4" />
       </button>

--- a/src/workbench/Workbench.tsx
+++ b/src/workbench/Workbench.tsx
@@ -6,6 +6,7 @@ import { useDialogSnapshot } from "@/components/ui/use-dialog-snapshot";
 import { Spinner } from "@/components/ui/spinner";
 import { useI18n } from "@/i18n";
 import { cn } from "@/lib/utils";
+import { ipc } from "@/lib/ipc";
 import { errorMessage, toast, useToastStore } from "@/lib/toast";
 import { useSettingSync } from "@/lib/settingSync";
 import { IS_MACOS } from "@/lib/platform";
@@ -128,9 +129,11 @@ export function Workbench() {
     const unlisten = installWindowListener(
       () =>
         getCurrentWindow().onCloseRequested((event) => {
-          if (useTabsStore.getState().requestWindowClose()) {
-            event.preventDefault();
-          }
+          // Closing the window hides it to the tray so the task scheduler keeps
+          // running; nothing is lost, so the dirty-file guard doesn't apply.
+          // Without preventDefault the JS API would destroy the webview.
+          event.preventDefault();
+          void ipc.window.hideToTray();
         }),
       (error) =>
         toast.error(t("windowControls.listenerError"), errorMessage(error)),


### PR DESCRIPTION
## 变更

关闭窗口时**隐藏到系统托盘/菜单栏**而非退出，保持进程与 webview 内的任务调度器存活，让 cron 计划任务继续按点触发。从托盘菜单或双击图标唤起；「退出」是唯一真正退出的入口。

## 关键点

- 新增托盘图标 + 中英文「显示 / 退出」菜单（`tray.rs`）
- 前端 `onCloseRequested` 必须 `preventDefault` 并隐藏，否则 `@tauri-apps/api` 的关闭流程会销毁 webview（连带杀死调度器）——这是本次真正的根因
- 拦截 `RunEvent::ExitRequested(code=None)` 以对抗 macOS「关闭最后一个窗口即退出」；显式退出（托盘退出 / 更新器 restart）照常放行
- macOS：隐藏时切 Accessory（仅菜单栏），唤起时恢复 Regular，并在 dev 构建重设 Dock 图标（避免 "exec" 占位图标）
- 全部托盘代码加 `#[cfg(desktop)]` 门控，不影响 mobile 构建

## 已知行为

- 托盘菜单语言在启动时按 `general.locale` 决定，应用内切语言需重启生效
- Linux：appindicator 不投递点击事件，唯菜单可交互（本设计以菜单为主入口，功能完整）

## 测试

macOS 实测通过（关闭/唤起/反复/退出/Dock 图标）；clippy、typecheck、lint 全绿；前端 422 + Rust 176 测试通过。