### PR TITLE
feat(keybindings): add configurable shortcuts for copy and paste

### DIFF
--- a/src-tauri/src/sync/settings_compat.rs
+++ b/src-tauri/src/sync/settings_compat.rs
@@ -104,6 +104,8 @@ fn is_keybinding_id(value: &str) -> bool {
             | "terminal.focusPreviousPane"
             | "terminal.focusNextPane"
             | "terminal.search"
+            | "terminal.copy"
+            | "terminal.paste"
             | "view.toggleSidebar"
             | "view.togglePanel"
             | "view.toggleAssistant"
@@ -257,6 +259,11 @@ mod tests {
         assert!(sanitize(&setting(
             "general.keybindings",
             r#"{"view.toggleSidebar":null,"terminal.search":"mod+shift+f"}"#
+        ))
+        .is_some());
+        assert!(sanitize(&setting(
+            "general.keybindings",
+            r#"{"terminal.copy":"ctrl+shift+c","terminal.paste":"ctrl+shift+v"}"#
         ))
         .is_some());
         assert!(sanitize(&setting("ai.protocol", "anthropic")).is_some());

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -215,6 +215,8 @@ export const en = {
       focusPreviousPane: "Focus previous terminal pane",
       focusNextPane: "Focus next terminal pane",
       search: "Find in terminal",
+      copy: "Copy terminal selection",
+      paste: "Paste into terminal",
     },
     palette: {
       quick: "Open quick connect",

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -211,6 +211,8 @@ export const zhCN: Dictionary = {
       focusPreviousPane: "聚焦上一个终端窗格",
       focusNextPane: "聚焦下一个终端窗格",
       search: "在终端中查找",
+      copy: "复制终端选区",
+      paste: "粘贴到终端",
     },
     palette: {
       quick: "打开快速连接",

--- a/src/workbench/commands.ts
+++ b/src/workbench/commands.ts
@@ -1,7 +1,11 @@
 import { useMemo } from "react";
 
+import { writeText } from "@tauri-apps/plugin-clipboard-manager";
+
 import { useI18n, type TKey } from "@/i18n";
 import { useBroadcastStore } from "@/features/terminal/broadcast";
+import { pasteIntoTerminal } from "@/features/terminal/paste";
+import { getSession } from "@/features/terminal/sessions";
 import { THEMES } from "@/themes";
 import { useTheme } from "@/themes/useTheme";
 import { useLayoutStore, type Activity } from "./layout";
@@ -12,7 +16,7 @@ import {
 } from "./keybinding-registry";
 import { useKeybindingStore } from "./keybinding-store";
 import { useOverlayStore } from "./overlays";
-import { useTabsStore } from "./tabs";
+import { activePane, useTabsStore, type TerminalPane } from "./tabs";
 
 export interface WorkbenchCommand {
   id: string;
@@ -37,6 +41,29 @@ function showActivity(activity: Activity) {
   if (layout.activity !== activity || !layout.sidebarVisible) {
     layout.selectActivity(activity);
   }
+}
+
+function activeTerminalPane(): TerminalPane | undefined {
+  const state = useTabsStore.getState();
+  const active = state.tabs.find((tab) => tab.id === state.activeId);
+  if (active?.kind !== "terminal") return;
+  return activePane(active);
+}
+
+export function copyActivePane(): void {
+  const pane = activeTerminalPane();
+  if (!pane) return;
+  const term = getSession(pane.id)?.term;
+  if (!term?.hasSelection()) return;
+  void writeText(term.getSelection());
+}
+
+export function pasteActivePane(): void {
+  const pane = activeTerminalPane();
+  if (!pane) return;
+  const session = getSession(pane.id);
+  if (!session) return;
+  void pasteIntoTerminal(session.term, { images: pane.target === "local" });
 }
 
 function commandShortcut(
@@ -110,6 +137,20 @@ export function useCommands(): WorkbenchCommand[] {
           keybindingOverrides,
         ),
         run: () => useTabsStore.getState().focusPaneNext(1),
+      },
+      {
+        id: "terminal.copy",
+        categoryKey: "commands.category.terminal",
+        label: t("commands.terminal.copy"),
+        shortcut: commandShortcut("terminal.copy", keybindingOverrides),
+        run: () => copyActivePane(),
+      },
+      {
+        id: "terminal.paste",
+        categoryKey: "commands.category.terminal",
+        label: t("commands.terminal.paste"),
+        shortcut: commandShortcut("terminal.paste", keybindingOverrides),
+        run: () => pasteActivePane(),
       },
       {
         id: "view.toggleSidebar",

--- a/src/workbench/keybinding-registry.ts
+++ b/src/workbench/keybinding-registry.ts
@@ -19,6 +19,8 @@ export type KeybindingId =
   | "terminal.focusPreviousPane"
   | "terminal.focusNextPane"
   | "terminal.search"
+  | "terminal.copy"
+  | "terminal.paste"
   | "view.toggleSidebar"
   | "view.togglePanel"
   | "view.toggleAssistant"
@@ -113,6 +115,18 @@ export const KEYBINDING_DEFINITIONS: readonly KeybindingDefinition[] = [
     categoryKey: "commands.category.terminal",
     labelKey: "commands.terminal.search",
     defaultBindings: ["mod+f"],
+  },
+  {
+    id: "terminal.copy",
+    categoryKey: "commands.category.terminal",
+    labelKey: "commands.terminal.copy",
+    defaultBindings: ["ctrl+shift+c"],
+  },
+  {
+    id: "terminal.paste",
+    categoryKey: "commands.category.terminal",
+    labelKey: "commands.terminal.paste",
+    defaultBindings: ["ctrl+shift+v"],
   },
   {
     id: "view.toggleSidebar",

--- a/src/workbench/keybindings.ts
+++ b/src/workbench/keybindings.ts
@@ -6,6 +6,7 @@ import { IS_MACOS } from "@/lib/platform";
 import { useLayoutStore } from "./layout";
 import { useOverlayStore } from "./overlays";
 import { useTabsStore } from "./tabs";
+import { copyActivePane, pasteActivePane } from "./commands";
 import { useZoomStore } from "./zoom";
 import { findKeybinding, type KeybindingId } from "./keybinding-registry";
 import { useKeybindingStore } from "./keybinding-store";
@@ -69,6 +70,10 @@ function runKeybinding(id: KeybindingId): void {
     if (active?.kind === "terminal") {
       useTerminalSearch.getState().open(active.activePaneId);
     }
+  } else if (id === "terminal.copy") {
+    copyActivePane();
+  } else if (id === "terminal.paste") {
+    pasteActivePane();
   } else if (id === "view.zoomIn") {
     useZoomStore.getState().zoomIn();
   } else if (id === "view.zoomOut") {


### PR DESCRIPTION
## Summary
添加了Ctrl-Shift-C和Ctrl-Shift-V作为复制粘贴的快捷键
## Changes

## Verification

- [ *] `pnpm lint && pnpm typecheck && pnpm test`
- [ *] `cargo fmt --check && cargo clippy -- -D warnings && cargo test`
- [ *] Exercised the affected flows in `pnpm tauri dev`
