### PR TITLE
fix: harden error recovery and async lifecycle

### DIFF
--- a/src/components/ui/error-boundary.test.tsx
+++ b/src/components/ui/error-boundary.test.tsx
@@ -1,0 +1,42 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import { ErrorBoundary } from "./error-boundary";
+
+function BrokenView(): never {
+  throw new Error("internal module path");
+}
+
+describe("ErrorBoundary", () => {
+  it("shows a localized generic recovery action without internal details", () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    render(
+      <ErrorBoundary>
+        <BrokenView />
+      </ErrorBoundary>,
+    );
+
+    expect(screen.getByText("Something went wrong")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Reload app" })).toBeTruthy();
+    expect(screen.queryByText("internal module path")).toBeNull();
+    consoleError.mockRestore();
+  });
+
+  it("supports an intentionally empty custom fallback", () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const { container } = render(
+      <ErrorBoundary fallback={null}>
+        <BrokenView />
+      </ErrorBoundary>,
+    );
+
+    expect(container.textContent).toBe("");
+    consoleError.mockRestore();
+  });
+});

--- a/src/components/ui/error-boundary.tsx
+++ b/src/components/ui/error-boundary.tsx
@@ -1,0 +1,51 @@
+import { Component, type ErrorInfo, type ReactNode } from "react";
+
+import { ErrorState } from "@/components/ui/empty-state";
+import { detectLocale } from "@/i18n/config";
+import { translate } from "@/i18n/translate";
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+  fallback?: ReactNode;
+  onError?: (error: Error, info: ErrorInfo) => void;
+}
+
+interface ErrorBoundaryState {
+  failed: boolean;
+}
+
+export class ErrorBoundary extends Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
+  state: ErrorBoundaryState = { failed: false };
+
+  static getDerivedStateFromError(): ErrorBoundaryState {
+    return { failed: true };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    this.props.onError?.(error, info);
+  }
+
+  render() {
+    if (this.state.failed) {
+      if (this.props.fallback !== undefined) return this.props.fallback;
+      return <ErrorFallback />;
+    }
+    return this.props.children;
+  }
+}
+
+function ErrorFallback() {
+  const locale = detectLocale();
+
+  return (
+    <ErrorState
+      title={translate(locale, "common.unexpectedError")}
+      retryLabel={translate(locale, "common.reloadApp")}
+      onRetry={() => window.location.reload()}
+      fill
+    />
+  );
+}

--- a/src/features/ai/AssistantPanel.tsx
+++ b/src/features/ai/AssistantPanel.tsx
@@ -714,13 +714,22 @@ const MARKDOWN_COMPONENTS: Components = {
 function CodeBlock({ code }: { code: string }) {
   const { t } = useI18n();
   const [copied, setCopied] = useState(false);
+  const copiedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const sendToTerminal = useTabsStore((s) => s.sendToTerminal);
+
+  useEffect(
+    () => () => {
+      if (copiedTimerRef.current) clearTimeout(copiedTimerRef.current);
+    },
+    [],
+  );
 
   const copy = async () => {
     try {
       await navigator.clipboard.writeText(code);
       setCopied(true);
-      setTimeout(() => setCopied(false), 1500);
+      if (copiedTimerRef.current) clearTimeout(copiedTimerRef.current);
+      copiedTimerRef.current = setTimeout(() => setCopied(false), 1500);
     } catch (err) {
       toast.error(t("ai.error"), errorMessage(err));
     }

--- a/src/features/ai/model-limits.test.ts
+++ b/src/features/ai/model-limits.test.ts
@@ -6,7 +6,11 @@ vi.mock("@/lib/ipc", () => ({
   ipc: { ai: { modelLimits } },
 }));
 
-import { clearModelLimitsCache, resolveModelLimits } from "./model-limits";
+import {
+  clearModelLimitsCache,
+  MAX_MODEL_LIMIT_CACHE_ENTRIES,
+  resolveModelLimits,
+} from "./model-limits";
 
 beforeEach(() => {
   clearModelLimitsCache();
@@ -53,5 +57,21 @@ describe("resolveModelLimits", () => {
     await expect(resolveModelLimits("offline-model")).resolves.toBeNull();
 
     expect(modelLimits).toHaveBeenCalledTimes(1);
+  });
+
+  it("evicts the least recently used model after reaching the cache limit", async () => {
+    modelLimits.mockResolvedValue({
+      contextWindow: 128_000,
+      maxOutputTokens: 16_000,
+    });
+
+    for (let index = 0; index <= MAX_MODEL_LIMIT_CACHE_ENTRIES; index += 1) {
+      await resolveModelLimits(`model-${index}`);
+    }
+    await resolveModelLimits("model-0");
+
+    expect(modelLimits).toHaveBeenCalledTimes(
+      MAX_MODEL_LIMIT_CACHE_ENTRIES + 2,
+    );
   });
 });

--- a/src/features/ai/model-limits.ts
+++ b/src/features/ai/model-limits.ts
@@ -3,6 +3,7 @@ import type { AiModelLimits } from "@/types/models";
 
 const SUCCESS_TTL_MS = 5 * 60_000;
 const FAILURE_TTL_MS = 30_000;
+export const MAX_MODEL_LIMIT_CACHE_ENTRIES = 100;
 
 interface CacheEntry {
   promise: Promise<AiModelLimits | null>;
@@ -20,7 +21,20 @@ export function resolveModelLimits(
 ): Promise<AiModelLimits | null> {
   const now = Date.now();
   const cached = cache.get(model);
-  if (cached && cached.expiresAt > now) return cached.promise;
+  if (cached && cached.expiresAt > now) {
+    cache.delete(model);
+    cache.set(model, cached);
+    return cached.promise;
+  }
+  if (cached) cache.delete(model);
+  for (const [key, entry] of cache) {
+    if (entry.expiresAt <= now) cache.delete(key);
+  }
+  while (cache.size >= MAX_MODEL_LIMIT_CACHE_ENTRIES) {
+    const oldest = cache.keys().next().value;
+    if (oldest === undefined) break;
+    cache.delete(oldest);
+  }
 
   const entry: CacheEntry = {
     promise: Promise.resolve(null),

--- a/src/features/credentials/CredentialsView.tsx
+++ b/src/features/credentials/CredentialsView.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { save } from "@tauri-apps/plugin-dialog";
 import {
   Check,
@@ -331,14 +331,23 @@ function KeyRow({
 }) {
   const { t } = useI18n();
   const [copied, setCopied] = useState(false);
+  const copiedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const tag = algorithmTag(sshKey.publicKey);
+
+  useEffect(
+    () => () => {
+      if (copiedTimerRef.current) clearTimeout(copiedTimerRef.current);
+    },
+    [],
+  );
 
   const copyPublicKey = async () => {
     if (!sshKey.publicKey) return;
     try {
       await navigator.clipboard.writeText(sshKey.publicKey);
       setCopied(true);
-      setTimeout(() => setCopied(false), 1500);
+      if (copiedTimerRef.current) clearTimeout(copiedTimerRef.current);
+      copiedTimerRef.current = setTimeout(() => setCopied(false), 1500);
     } catch (err) {
       toast.error(t("credentials.keys.copyError"), errorMessage(err));
     }

--- a/src/features/forwards/store.test.ts
+++ b/src/features/forwards/store.test.ts
@@ -45,6 +45,9 @@ describe("forward runtime state", () => {
       },
     );
     mocks.runtime.mockRejectedValueOnce(new Error("snapshot failed"));
+    mocks.unlisten.mockImplementationOnce(() => {
+      throw new Error("cleanup failed");
+    });
     await expect(bridgeForwardEvents()).rejects.toThrow("snapshot failed");
     expect(mocks.unlisten).toHaveBeenCalledOnce();
 

--- a/src/features/forwards/store.ts
+++ b/src/features/forwards/store.ts
@@ -74,7 +74,9 @@ export function bridgeForwardEvents(): Promise<void> {
       const snapshot = await ipc.forwards.runtime();
       useForwardStore.getState().hydrate(snapshot);
     } catch (error) {
-      unlisten();
+      try {
+        unlisten();
+      } catch {}
       throw error;
     }
     for (const event of queued) useForwardStore.getState().apply(event);

--- a/src/features/monitor/MonitorView.tsx
+++ b/src/features/monitor/MonitorView.tsx
@@ -18,6 +18,7 @@ import {
   useMonitorStore,
 } from "@/features/terminal/monitor";
 import { useI18n, type TFunction, type TKey } from "@/i18n";
+import { errorMessage, toast } from "@/lib/toast";
 import { cn, formatBytes, formatUsage } from "@/lib/utils";
 import type { Host, HostStats } from "@/types/models";
 import { PanelContent } from "@/workbench/PanelHeader";
@@ -38,8 +39,10 @@ export function MonitorView() {
   const searching = query.trim().length > 0;
 
   useEffect(() => {
-    void bridgeMonitorEvents().catch(() => {});
-  }, []);
+    void bridgeMonitorEvents().catch((error) =>
+      toast.error(t("monitor.listenerError"), errorMessage(error)),
+    );
+  }, [t]);
 
   const groups = groupByHost(
     terminalPanes(tabs).filter((pane) => pane.target !== "local"),

--- a/src/features/sftp/SftpPanel.tsx
+++ b/src/features/sftp/SftpPanel.tsx
@@ -45,6 +45,7 @@ export function SftpPanel({ height }: { height: number }) {
   const [historyOpen, setHistoryOpen] = useState(false);
   const pendingConflict = useSftpStore((s) => s.pendingConflict);
   const resolveConflict = useSftpStore((s) => s.resolveConflict);
+  const cancelConflict = useSftpStore((s) => s.cancelConflict);
   const setConflictApplyToRemaining = useSftpStore(
     (s) => s.setConflictApplyToRemaining,
   );
@@ -54,6 +55,8 @@ export function SftpPanel({ height }: { height: number }) {
   useEffect(() => {
     void ensureLocalTab("left");
   }, [ensureLocalTab]);
+
+  useEffect(() => () => cancelConflict(), [cancelConflict]);
 
   const bodyWidth = () => bodyRef.current?.getBoundingClientRect().width ?? 0;
 

--- a/src/features/sftp/store.test.ts
+++ b/src/features/sftp/store.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@/lib/ipc", () => ({
   ipc: {
@@ -9,6 +9,8 @@ vi.mock("@/lib/ipc", () => ({
       cancelTransfer: vi.fn(() => Promise.resolve()),
       deleteBatch: vi.fn(() => Promise.resolve()),
       cancelDelete: vi.fn(() => Promise.resolve()),
+      connect: vi.fn(() => Promise.resolve()),
+      disconnect: vi.fn(() => Promise.resolve()),
     },
   },
 }));
@@ -34,6 +36,8 @@ import {
 } from "./store";
 
 const refreshDirectory = useSftpStore.getState().refresh;
+
+afterEach(() => useSftpStore.getState().cancelConflict());
 
 const loadedTab = (): SftpTab => ({
   id: "local-tab",
@@ -366,6 +370,120 @@ describe("SFTP transfer refresh", () => {
       totalBytes: 1024,
       status: "active",
     });
+  });
+});
+
+describe("SFTP connection races", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useSftpStore.setState({
+      panes: {
+        left: {
+          tabs: [transferTab("remote", "connection-1", "")],
+          activeTabId: "remote",
+        },
+        right: { tabs: [], activeTabId: null },
+      },
+      transfers: {},
+      deletions: {},
+      pendingConflict: null,
+    });
+    useSftpStore.setState((state) => ({
+      panes: {
+        ...state.panes,
+        left: {
+          ...state.panes.left,
+          tabs: state.panes.left.tabs.map((tab) => ({
+            ...tab,
+            hostId: "host-1",
+            status: "connecting" as const,
+          })),
+        },
+      },
+    }));
+  });
+
+  it("does not reconnect a tab after it is closed", async () => {
+    let finishDisconnect: (() => void) | undefined;
+    vi.mocked(ipc.sftp.disconnect).mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          finishDisconnect = resolve;
+        }),
+    );
+
+    useSftpStore.getState().reconnectTab("left", "remote");
+    useSftpStore.getState().closeTab("left", "remote");
+    finishDisconnect?.();
+
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(ipc.sftp.connect).not.toHaveBeenCalled();
+  });
+
+  it("ignores home directory recovery from an earlier connection", async () => {
+    let finishHome: ((path: string) => void) | undefined;
+    vi.mocked(ipc.sftp.home).mockImplementationOnce(
+      () =>
+        new Promise<string>((resolve) => {
+          finishHome = resolve;
+        }),
+    );
+
+    useSftpStore.getState().applyStatus("connection-1", "connected");
+    useSftpStore.getState().reconnectTab("left", "remote");
+    finishHome?.("/stale-home");
+
+    await vi.waitFor(() => expect(ipc.sftp.home).toHaveBeenCalled());
+    expect(ipc.sftp.list).not.toHaveBeenCalled();
+    expect(useSftpStore.getState().panes.left.tabs[0]?.cwd).toBe("");
+  });
+});
+
+describe("SFTP conflict lifecycle", () => {
+  it("cancels a waiting transfer when an involved tab closes", async () => {
+    const entry: FileEntry = {
+      name: "report.txt",
+      path: "/source/report.txt",
+      kind: "file",
+      size: 10,
+      modified: null,
+      permissions: null,
+      isSymlink: false,
+    };
+    const destination = { ...entry, path: "/destination/report.txt" };
+    useSftpStore.setState({
+      panes: {
+        left: {
+          tabs: [
+            { ...transferTab("source", null, "/source"), entries: [entry] },
+          ],
+          activeTabId: "source",
+        },
+        right: {
+          tabs: [
+            {
+              ...transferTab("destination", null, "/destination"),
+              entries: [destination],
+            },
+          ],
+          activeTabId: "destination",
+        },
+      },
+      transfers: {},
+      deletions: {},
+      pendingConflict: null,
+    });
+
+    const transfer = useSftpStore.getState().transfer("left", [entry]);
+    await vi.waitFor(() =>
+      expect(useSftpStore.getState().pendingConflict).not.toBeNull(),
+    );
+    useSftpStore.getState().closeTab("right", "destination");
+    await transfer;
+
+    expect(useSftpStore.getState().pendingConflict).toBeNull();
+    expect(ipc.sftp.transfer).not.toHaveBeenCalled();
   });
 });
 

--- a/src/features/sftp/store.ts
+++ b/src/features/sftp/store.ts
@@ -98,6 +98,8 @@ interface SftpState {
     name: string;
     remaining: number;
     applyToRemaining: boolean;
+    sourceTabId: string;
+    destinationTabId: string;
   } | null;
 
   setRatio: (r: number) => void;
@@ -105,6 +107,7 @@ interface SftpState {
   toggleFileToolbar: () => void;
   setConflictApplyToRemaining: (value: boolean) => void;
   resolveConflict: (decision: ConflictAction) => void;
+  cancelConflict: () => void;
 
   ensureLocalTab: (side: PaneSide) => Promise<void>;
   addLocalTab: (side: PaneSide) => Promise<void>;
@@ -149,7 +152,10 @@ const otherSide = (side: PaneSide): PaneSide =>
   side === "left" ? "right" : "left";
 
 type ConflictAction = "skip" | "rename" | "overwrite";
-type ConflictDecision = { action: ConflictAction; applyToRemaining: boolean };
+type ConflictDecision = {
+  action: ConflictAction | "cancel";
+  applyToRemaining: boolean;
+};
 
 let conflictResolver: ((decision: ConflictDecision) => void) | null = null;
 
@@ -266,6 +272,7 @@ export function bridgeSftpEvents(): Promise<void> {
 
 export const useSftpStore = create<SftpState>((set, get) => {
   const navigationRequests = new Map<string, number>();
+  const connectionRequests = new Map<string, symbol>();
 
   const canAddTab = (notify = true) => {
     const { left, right } = get().panes;
@@ -305,6 +312,13 @@ export const useSftpStore = create<SftpState>((set, get) => {
       if (tab) return { side, tab };
     }
     return null;
+  };
+
+  const cancelConflict = () => {
+    const resolve = conflictResolver;
+    conflictResolver = null;
+    set({ pendingConflict: null });
+    resolve?.({ action: "cancel", applyToRemaining: false });
   };
 
   const loadEntries = async (
@@ -385,6 +399,7 @@ export const useSftpStore = create<SftpState>((set, get) => {
       set({ pendingConflict: null });
       resolve?.({ action: decision, applyToRemaining });
     },
+    cancelConflict,
 
     ensureLocalTab: async (side) => {
       if (get().panes[side].tabs.length > 0 || !canAddTab(false)) return;
@@ -458,6 +473,11 @@ export const useSftpStore = create<SftpState>((set, get) => {
       const tab = get().panes[side].tabs.find((item) => item.id === tabId);
       if (!tab || tab.kind !== "remote" || !tab.connectionId || !tab.hostId)
         return;
+      const connectionId = tab.connectionId;
+      const hostId = tab.hostId;
+      const request = Symbol(tabId);
+      connectionRequests.set(tabId, request);
+      navigationRequests.set(tabId, (navigationRequests.get(tabId) ?? 0) + 1);
       patchTab(side, tabId, {
         status: "connecting",
         loading: true,
@@ -467,10 +487,24 @@ export const useSftpStore = create<SftpState>((set, get) => {
         selected: [],
       });
       void ipc.sftp
-        .disconnect(tab.connectionId)
+        .disconnect(connectionId)
         .catch(() => {})
-        .then(() => ipc.sftp.connect(tab.connectionId!, tab.hostId!))
+        .then(() => {
+          const current = get().panes[side].tabs.find(
+            (item) => item.id === tabId,
+          );
+          if (
+            connectionRequests.get(tabId) !== request ||
+            current?.kind !== "remote" ||
+            current.connectionId !== connectionId ||
+            current.hostId !== hostId
+          ) {
+            return;
+          }
+          return ipc.sftp.connect(connectionId, hostId);
+        })
         .catch((err) => {
+          if (connectionRequests.get(tabId) !== request) return;
           patchTab(side, tabId, {
             status: "error",
             loading: false,
@@ -483,6 +517,14 @@ export const useSftpStore = create<SftpState>((set, get) => {
       const pane = get().panes[side];
       const tab = pane.tabs.find((t) => t.id === tabId);
       navigationRequests.delete(tabId);
+      connectionRequests.delete(tabId);
+      const pendingConflict = get().pendingConflict;
+      if (
+        pendingConflict?.sourceTabId === tabId ||
+        pendingConflict?.destinationTabId === tabId
+      ) {
+        cancelConflict();
+      }
       if (tab?.kind === "remote" && tab.connectionId) {
         for (const transfer of Object.values(get().transfers)) {
           if (
@@ -572,17 +614,28 @@ export const useSftpStore = create<SftpState>((set, get) => {
       const { side, tab } = found;
 
       if (status === "connected" && !tab.cwd) {
+        const request = connectionRequests.get(tab.id);
+        const isCurrentConnection = () => {
+          const current = get().panes[side].tabs.find(
+            (candidate) => candidate.id === tab.id,
+          );
+          return (
+            current?.connectionId === connectionId &&
+            current.status === "connecting" &&
+            connectionRequests.get(tab.id) === request
+          );
+        };
         void (async () => {
           let error: string | undefined;
           try {
             const home = await ipc.sftp.home(connectionId);
+            if (!isCurrentConnection()) return;
             await loadEntries(side, tab.id, home);
           } catch (err) {
             error = errorMessage(err);
           }
 
-          const current = get().panes[side].tabs.find((x) => x.id === tab.id);
-          if (!current || current.status !== "connecting") return;
+          if (!isCurrentConnection()) return;
           patchTab(side, tab.id, {
             status: "connected",
             loading: false,
@@ -794,9 +847,12 @@ export const useSftpStore = create<SftpState>((set, get) => {
                     name: item.name,
                     remaining: items.length - index - 1,
                     applyToRemaining: false,
+                    sourceTabId: srcTab.id,
+                    destinationTabId: dstTab.id,
                   },
                 });
               });
+          if (decision.action === "cancel") return;
           if (decision.applyToRemaining) batchDecision = decision.action;
           if (decision.action === "skip") continue;
           if (decision.action === "rename") {

--- a/src/features/tasks/store.test.ts
+++ b/src/features/tasks/store.test.ts
@@ -47,6 +47,21 @@ describe("task runs", () => {
     useToastStore.setState({ toasts: [] });
   });
 
+  it("continues a run and reports a transfer listener failure", async () => {
+    const error = new Error("listener failed");
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.mocked(ipc.sftp.onTransfer).mockRejectedValueOnce(error);
+
+    await useTaskRunStore.getState().startRun(task(), "h1").completion;
+
+    expect(ipc.tasks.run).toHaveBeenCalledOnce();
+    expect(warn).toHaveBeenCalledWith(
+      "Failed to initialize task transfer progress:",
+      error,
+    );
+    warn.mockRestore();
+  });
+
   it("reports the finished run to callers that never attached", async () => {
     vi.mocked(ipc.tasks.run).mockImplementation(
       async (_id, _hostId, onEvent: (event: TaskRunEvent) => void) => {

--- a/src/features/tasks/store.ts
+++ b/src/features/tasks/store.ts
@@ -232,7 +232,9 @@ export const useTaskRunStore = create<TaskRunState>((set, get) => {
 
       const completion = (async () => {
         try {
-          await ensureTransferBridge().catch(() => {});
+          await ensureTransferBridge().catch((error) =>
+            console.warn("Failed to initialize task transfer progress:", error),
+          );
           await ipc.tasks.run(
             task.id,
             hostId,

--- a/src/features/terminal/TerminalView.tsx
+++ b/src/features/terminal/TerminalView.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from "react";
 
 import { useI18n } from "@/i18n";
+import { errorMessage, toast } from "@/lib/toast";
 import { useTheme } from "@/themes/useTheme";
 import {
   terminalPanes,
@@ -15,7 +16,7 @@ import { createAutocomplete } from "./autocomplete/controller";
 import { broadcastTargets, useBroadcastStore } from "./broadcast";
 import { useHostKeyStore } from "./host-key";
 import { usePasswordPromptStore } from "./password-prompt";
-import { bridgeMonitorEvents, startMonitor, stopMonitor } from "./monitor";
+import { startMonitor, stopMonitor } from "./monitor";
 import { TerminalSession } from "./session";
 import { disposeSession, getSession, registerSession } from "./sessions";
 import { localTransport, sshAdhocTransport, sshTransport } from "./transport";
@@ -72,8 +73,6 @@ export function TerminalView({
       : target === "ssh-adhoc" && adhoc
         ? sshAdhocTransport(sessionId, attempt, adhoc)
         : sshTransport(sessionId, hostId, attempt);
-    if (isSshLike) void bridgeMonitorEvents().catch(() => {});
-
     const describeError = (code?: string | null, message?: string) => {
       const translate = translateRef.current;
       if (code === "invalid") return translate("ssh.credentialsMissing");
@@ -104,7 +103,12 @@ export function TerminalView({
       onStatus: (e) => {
         if (isSshLike) {
           if (e.status === "connected") {
-            void startMonitor(sessionId, attempt).catch(() => {});
+            void startMonitor(sessionId, attempt).catch((error) =>
+              toast.error(
+                translateRef.current("monitor.listenerError"),
+                errorMessage(error),
+              ),
+            );
           } else if (e.status === "closed" || e.status === "error") {
             stopMonitor(sessionId, attempt);
             useHostKeyStore.getState().rejectSession(sessionId);

--- a/src/features/terminal/host-key.test.ts
+++ b/src/features/terminal/host-key.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { HostKeyEvent } from "@/types/models";
 
@@ -58,6 +58,8 @@ describe("host key prompts", () => {
     useHostKeyStore.setState({ queue: [] });
   });
 
+  afterEach(() => vi.useRealTimers());
+
   it("recovers and deduplicates a prompt emitted before listening", async () => {
     mocks.pendingHostKeys.mockImplementation(async () => {
       mocks.promptListener?.(prompt("pending"));
@@ -68,6 +70,20 @@ describe("host key prompts", () => {
 
     expect(useHostKeyStore.getState().queue).toEqual([prompt("pending")]);
     expect(hasHostKeyPrompt("session-1")).toBe(true);
+  });
+
+  it("retries a failed pending host key query", async () => {
+    vi.useFakeTimers();
+    mocks.pendingHostKeys
+      .mockRejectedValueOnce(new Error("temporarily unavailable"))
+      .mockResolvedValueOnce([prompt("recovered")]);
+
+    const listening = listenHostKeyEvents();
+    await vi.runAllTimersAsync();
+    await listening;
+
+    expect(mocks.pendingHostKeys).toHaveBeenCalledTimes(2);
+    expect(useHostKeyStore.getState().queue).toEqual([prompt("recovered")]);
   });
 
   it("removes the first listener when the second listener fails", async () => {

--- a/src/features/terminal/host-key.ts
+++ b/src/features/terminal/host-key.ts
@@ -2,6 +2,7 @@ import { create } from "zustand";
 
 import { ipc } from "@/lib/ipc";
 import type { HostKeyDecision, HostKeyEvent } from "@/types/models";
+import { recoverPendingPrompts } from "./prompt-recovery";
 
 interface HostKeyState {
   queue: HostKeyEvent[];
@@ -64,13 +65,16 @@ export async function listenHostKeyEvents(): Promise<() => void> {
     throw error;
   }
   try {
-    const pending = await ipc.ssh.pendingHostKeys();
-    for (const event of pending) {
-      if (!closedDuringSync.has(event.promptId)) {
-        useHostKeyStore.getState().push(event);
-      }
-    }
-  } catch {
+    await recoverPendingPrompts(
+      () => ipc.ssh.pendingHostKeys(),
+      (event) => {
+        if (!closedDuringSync.has(event.promptId)) {
+          useHostKeyStore.getState().push(event);
+        }
+      },
+      (error) =>
+        console.warn("Failed to recover pending host key prompts:", error),
+    );
   } finally {
     syncing = false;
   }

--- a/src/features/terminal/monitor.ts
+++ b/src/features/terminal/monitor.ts
@@ -81,10 +81,12 @@ export async function startMonitor(sessionId: string, attempt: number) {
   if (current && current.attempt !== attempt) {
     useMonitorStore.getState().clear(sessionId);
   }
-  void bridgeMonitorEvents()
-    .catch(() => bridgeMonitorEvents())
-    .catch(() => {});
   try {
+    try {
+      await bridgeMonitorEvents();
+    } catch {
+      await bridgeMonitorEvents();
+    }
     await ipc.monitor.start(sessionId, attempt);
   } catch (error) {
     if (started.get(sessionId) === attempt) started.delete(sessionId);

--- a/src/features/terminal/password-prompt.test.ts
+++ b/src/features/terminal/password-prompt.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 interface PasswordPrompt {
   promptId: string;
@@ -64,6 +64,8 @@ describe("password prompts", () => {
     usePasswordPromptStore.setState({ queue: [] });
   });
 
+  afterEach(() => vi.useRealTimers());
+
   it("recovers a prompt emitted before the event listener was ready", async () => {
     mocks.pendingPasswords.mockResolvedValue([prompt("pending")]);
 
@@ -73,6 +75,40 @@ describe("password prompts", () => {
       prompt("pending"),
     ]);
     expect(hasPasswordPrompt("session-1")).toBe(true);
+  });
+
+  it("retries a failed pending prompt query", async () => {
+    vi.useFakeTimers();
+    mocks.pendingPasswords
+      .mockRejectedValueOnce(new Error("temporarily unavailable"))
+      .mockResolvedValueOnce([prompt("recovered")]);
+
+    const listening = listenPasswordPrompts();
+    await vi.runAllTimersAsync();
+    await listening;
+
+    expect(mocks.pendingPasswords).toHaveBeenCalledTimes(2);
+    expect(usePasswordPromptStore.getState().queue).toEqual([
+      prompt("recovered"),
+    ]);
+  });
+
+  it("reports a pending prompt query after retries are exhausted", async () => {
+    vi.useFakeTimers();
+    const error = new Error("unavailable");
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    mocks.pendingPasswords.mockRejectedValue(error);
+
+    const listening = listenPasswordPrompts();
+    await vi.runAllTimersAsync();
+    await listening;
+
+    expect(mocks.pendingPasswords).toHaveBeenCalledTimes(3);
+    expect(warn).toHaveBeenCalledWith(
+      "Failed to recover pending password prompts:",
+      error,
+    );
+    warn.mockRestore();
   });
 
   it("removes the first listener when the second listener fails", async () => {

--- a/src/features/terminal/password-prompt.ts
+++ b/src/features/terminal/password-prompt.ts
@@ -2,6 +2,7 @@ import { create } from "zustand";
 
 import { ipc } from "@/lib/ipc";
 import type { PasswordPromptEvent } from "@/types/models";
+import { recoverPendingPrompts } from "./prompt-recovery";
 
 interface PasswordPromptState {
   queue: PasswordPromptEvent[];
@@ -69,13 +70,16 @@ export async function listenPasswordPrompts(): Promise<() => void> {
   }
 
   try {
-    const pending = await ipc.ssh.pendingPasswords();
-    for (const event of pending) {
-      if (!closedDuringSync.has(event.promptId)) {
-        usePasswordPromptStore.getState().push(event);
-      }
-    }
-  } catch {
+    await recoverPendingPrompts(
+      () => ipc.ssh.pendingPasswords(),
+      (event) => {
+        if (!closedDuringSync.has(event.promptId)) {
+          usePasswordPromptStore.getState().push(event);
+        }
+      },
+      (error) =>
+        console.warn("Failed to recover pending password prompts:", error),
+    );
   } finally {
     syncing = false;
   }

--- a/src/features/terminal/prompt-recovery.ts
+++ b/src/features/terminal/prompt-recovery.ts
@@ -1,0 +1,23 @@
+const RECOVERY_ATTEMPTS = 3;
+const RECOVERY_RETRY_MS = 100;
+
+export async function recoverPendingPrompts<T>(
+  load: () => Promise<T[]>,
+  accept: (event: T) => void,
+  onError: (error: unknown) => void,
+): Promise<void> {
+  for (let attempt = 1; attempt <= RECOVERY_ATTEMPTS; attempt += 1) {
+    try {
+      for (const event of await load()) accept(event);
+      return;
+    } catch (error) {
+      if (attempt === RECOVERY_ATTEMPTS) {
+        onError(error);
+        return;
+      }
+      await new Promise<void>((resolve) =>
+        globalThis.setTimeout(resolve, RECOVERY_RETRY_MS * attempt),
+      );
+    }
+  }
+}

--- a/src/features/terminal/session.test.ts
+++ b/src/features/terminal/session.test.ts
@@ -95,6 +95,37 @@ describe("TerminalSession lifecycle", () => {
     session.dispose();
   });
 
+  it("contains errors thrown by the status handler", async () => {
+    const current = transport();
+    const error = new Error("status failed");
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const session = new TerminalSession({
+      id: "session-1",
+      connectionKey: "attempt-1",
+      transport: current,
+      fontFamily: "monospace",
+      fontSize: 13,
+      theme: {},
+      watchHostKey: false,
+      imagePaste: false,
+      onStatus: () => {
+        throw error;
+      },
+    });
+
+    session.attach({} as HTMLElement);
+
+    await vi.waitFor(() => expect(current.connect).toHaveBeenCalledOnce());
+    expect(consoleError).toHaveBeenCalledWith(
+      "Terminal status handler failed:",
+      error,
+    );
+    consoleError.mockRestore();
+    session.dispose();
+  });
+
   it("routes key events between workbench shortcuts and the custom handler", async () => {
     const session = new TerminalSession({
       id: "session-1",

--- a/src/features/terminal/session.ts
+++ b/src/features/terminal/session.ts
@@ -162,7 +162,11 @@ export class TerminalSession {
         this.term.focus();
       }
       this.observe(container);
-      void this.start();
+      void this.start().catch((error) => {
+        console.error("Failed to start terminal session:", error);
+        if (!this.disposed) this.ended = true;
+        this.disconnectTransport();
+      });
     } catch (err) {
       if (!this.disposed) {
         this.ended = true;
@@ -346,7 +350,11 @@ export class TerminalSession {
   }
 
   private emitStatus(event: SessionStatusEvent) {
-    this.opts.onStatus(event);
+    try {
+      this.opts.onStatus(event);
+    } catch (error) {
+      console.error("Terminal status handler failed:", error);
+    }
   }
 
   private flushInput() {

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -10,6 +10,7 @@ export const en = {
     delete: "Delete",
     edit: "Edit",
     rename: "Rename",
+    reloadApp: "Reload app",
     retry: "Retry",
     save: "Save",
     saveChanges: "Save changes",
@@ -96,6 +97,7 @@ export const en = {
     uptimeHm: "{h}h {m}m",
     uptimeM: "{m}m",
     collecting: "Collecting statistics…",
+    listenerError: "Failed to initialize monitoring",
     unsupported: "Statistics aren't available on this system.",
     empty: {
       title: "No active sessions",

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -12,6 +12,7 @@ export const zhCN: Dictionary = {
     delete: "删除",
     edit: "编辑",
     rename: "重命名",
+    reloadApp: "重新加载应用",
     retry: "重试",
     save: "保存",
     saveChanges: "保存更改",
@@ -93,6 +94,7 @@ export const zhCN: Dictionary = {
     uptimeHm: "{h} 小时 {m} 分钟",
     uptimeM: "{m} 分钟",
     collecting: "正在采集统计信息…",
+    listenerError: "监控初始化失败",
     unsupported: "该系统暂不支持统计信息。",
     empty: {
       title: "暂无活动会话",

--- a/src/lib/cron.test.ts
+++ b/src/lib/cron.test.ts
@@ -30,6 +30,8 @@ describe("parseCron", () => {
       "5-1 * * * *",
       "abc * * * *",
       "5/10 * * * *",
+      "*/2/3 * * * *",
+      "1-2-3 * * * *",
       "* * * * 1-",
     ]) {
       expect(isValidCron(expr), expr).toBe(false);

--- a/src/lib/cron.ts
+++ b/src/lib/cron.ts
@@ -25,7 +25,9 @@ function parseField(field: string, range: FieldRange): Set<number> | null {
   if (field === "") return null;
   const values = new Set<number>();
   for (const part of field.split(",")) {
-    const [rangePart, stepPart] = part.split("/");
+    const stepParts = part.split("/");
+    if (stepParts.length > 2) return null;
+    const [rangePart, stepPart] = stepParts;
     let step = 1;
     if (stepPart !== undefined) {
       if (!/^\d+$/.test(stepPart)) return null;
@@ -36,7 +38,9 @@ function parseField(field: string, range: FieldRange): Set<number> | null {
     let start = range.min;
     let end = range.max;
     if (rangePart.includes("-")) {
-      const [a, b] = rangePart.split("-");
+      const rangeParts = rangePart.split("-");
+      if (rangeParts.length !== 2) return null;
+      const [a, b] = rangeParts;
       if (!/^\d+$/.test(a) || !/^\d+$/.test(b)) return null;
       start = Number(a);
       end = Number(b);

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,7 @@ import ReactDOM from "react-dom/client";
 
 import { AppProviders } from "@/app/providers";
 import App from "@/App";
+import { ErrorBoundary } from "@/components/ui/error-boundary";
 import { DEFAULT_LOCALE, detectLocale } from "@/i18n/config";
 import { loadLocale } from "@/i18n/translate";
 import "@/styles/globals.css";
@@ -15,9 +16,11 @@ async function start() {
   }
   ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
     <React.StrictMode>
-      <AppProviders>
-        <App />
-      </AppProviders>
+      <ErrorBoundary>
+        <AppProviders>
+          <App />
+        </AppProviders>
+      </ErrorBoundary>
     </React.StrictMode>,
   );
 }

--- a/src/workbench/EditorArea.tsx
+++ b/src/workbench/EditorArea.tsx
@@ -32,6 +32,7 @@ import {
   INTERACTIVE_FOCUS_CLASS,
 } from "@/components/ui";
 import { type ConfirmState } from "@/components/ui/confirm-dialog";
+import { ErrorBoundary } from "@/components/ui/error-boundary";
 import { Kbd } from "@/components/ui/kbd";
 import { Spinner } from "@/components/ui/spinner";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
@@ -358,6 +359,24 @@ export const EditorArea = memo(function EditorArea() {
     else focusFileEditor(activeId);
   }, [activeId, activePaneId]);
 
+  useEffect(() => {
+    const tabStrip = stripRef.current;
+    if (!tabStrip) return;
+    const handleWheel = (event: WheelEvent) => {
+      if (
+        tabStrip.scrollWidth <= tabStrip.clientWidth ||
+        event.deltaX !== 0 ||
+        event.deltaY === 0
+      ) {
+        return;
+      }
+      event.preventDefault();
+      tabStrip.scrollLeft += event.deltaY;
+    };
+    tabStrip.addEventListener("wheel", handleWheel, { passive: false });
+    return () => tabStrip.removeEventListener("wheel", handleWheel);
+  }, [tabs.length]);
+
   if (tabs.length === 0) return <Watermark />;
 
   return (
@@ -374,13 +393,6 @@ export const EditorArea = memo(function EditorArea() {
         <div className="relative shrink-0 bg-surface">
           <div
             ref={stripRef}
-            onWheel={(e) => {
-              const el = stripRef.current;
-              if (!el || el.scrollWidth <= el.clientWidth || e.deltaX !== 0) {
-                return;
-              }
-              el.scrollLeft += e.deltaY;
-            }}
             className={cn(
               "scrollbar-none flex h-[var(--workbench-bar-height)] gap-1 overflow-x-auto overflow-y-hidden",
               WORKBENCH_TAB_STRIP_GUTTER_CLASS,
@@ -458,28 +470,32 @@ export const EditorArea = memo(function EditorArea() {
                   tab.id !== activeId && "invisible opacity-0",
                 )}
               >
-                <Suspense fallback={<EditorLoading />}>
-                  {tab.kind === "terminal" ? (
-                    <TerminalEditor tab={tab} active={tab.id === activeId} />
-                  ) : (
-                    <FileEditor tab={tab} />
-                  )}
-                </Suspense>
+                <ErrorBoundary>
+                  <Suspense fallback={<EditorLoading />}>
+                    {tab.kind === "terminal" ? (
+                      <TerminalEditor tab={tab} active={tab.id === activeId} />
+                    ) : (
+                      <FileEditor tab={tab} />
+                    )}
+                  </Suspense>
+                </ErrorBoundary>
               </div>
             </TabsContent>
           ))}
         </div>
 
         {(pendingWindowClose || pendingTab) && (
-          <Suspense fallback={null}>
-            <ConfirmDialog
-              state={confirmState}
-              onClose={() => {
-                if (pendingWindowClose) clearPendingWindowClose();
-                else clearPendingClose();
-              }}
-            />
-          </Suspense>
+          <ErrorBoundary>
+            <Suspense fallback={null}>
+              <ConfirmDialog
+                state={confirmState}
+                onClose={() => {
+                  if (pendingWindowClose) clearPendingWindowClose();
+                  else clearPendingClose();
+                }}
+              />
+            </Suspense>
+          </ErrorBoundary>
         )}
       </div>
     </Tabs>

--- a/src/workbench/SideBar.tsx
+++ b/src/workbench/SideBar.tsx
@@ -1,5 +1,6 @@
 import { lazy, memo, Suspense } from "react";
 
+import { ErrorBoundary } from "@/components/ui/error-boundary";
 import { Spinner } from "@/components/ui/spinner";
 import { useLayoutStore } from "./layout";
 
@@ -47,20 +48,22 @@ export const SideBar = memo(function SideBar({ width }: { width: number }) {
       style={{ width }}
       className="flex shrink-0 flex-col overflow-hidden bg-surface"
     >
-      <Suspense
-        fallback={
-          <div className="flex flex-1 items-center justify-center">
-            <Spinner />
-          </div>
-        }
-      >
-        {activity === "hosts" && <HostsView />}
-        {activity === "credentials" && <CredentialsView />}
-        {activity === "snippets" && <SnippetsView />}
-        {activity === "tasks" && <TasksView />}
-        {activity === "forwards" && <ForwardsView />}
-        {activity === "monitor" && <MonitorView />}
-      </Suspense>
+      <ErrorBoundary>
+        <Suspense
+          fallback={
+            <div className="flex flex-1 items-center justify-center">
+              <Spinner />
+            </div>
+          }
+        >
+          {activity === "hosts" && <HostsView />}
+          {activity === "credentials" && <CredentialsView />}
+          {activity === "snippets" && <SnippetsView />}
+          {activity === "tasks" && <TasksView />}
+          {activity === "forwards" && <ForwardsView />}
+          {activity === "monitor" && <MonitorView />}
+        </Suspense>
+      </ErrorBoundary>
     </aside>
   );
 });

--- a/src/workbench/Workbench.tsx
+++ b/src/workbench/Workbench.tsx
@@ -1,6 +1,7 @@
 import { lazy, Suspense, useEffect, useState } from "react";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 
+import { ErrorBoundary } from "@/components/ui/error-boundary";
 import { ResizeHandle } from "@/components/ui/resize-handle";
 import { useDialogSnapshot } from "@/components/ui/use-dialog-snapshot";
 import { Spinner } from "@/components/ui/spinner";
@@ -316,9 +317,11 @@ export function Workbench() {
                 showLine={false}
                 highlightOffset={0.5}
               />
-              <Suspense fallback={<FeatureLoading height={panelHeight} />}>
-                <SftpPanel height={panelHeight} />
-              </Suspense>
+              <ErrorBoundary>
+                <Suspense fallback={<FeatureLoading height={panelHeight} />}>
+                  <SftpPanel height={panelHeight} />
+                </Suspense>
+              </ErrorBoundary>
             </>
           )}
         </div>
@@ -335,9 +338,11 @@ export function Workbench() {
               showLine={false}
               highlightOffset={-0.5}
             />
-            <Suspense fallback={<FeatureLoading width={auxWidth} />}>
-              <AssistantPanel width={auxWidth} />
-            </Suspense>
+            <ErrorBoundary>
+              <Suspense fallback={<FeatureLoading width={auxWidth} />}>
+                <AssistantPanel width={auxWidth} />
+              </Suspense>
+            </ErrorBoundary>
           </>
         )}
       </div>
@@ -345,57 +350,71 @@ export function Workbench() {
       <StatusBar />
 
       {shownOverlay?.type === "host-form" && (
-        <Suspense fallback={null}>
-          <HostFormDialog
-            open={overlay?.type === "host-form"}
-            hostId={shownOverlay.hostId}
-            initialGroupId={shownOverlay.groupId}
-            onClose={closeOverlay}
-          />
-        </Suspense>
+        <ErrorBoundary>
+          <Suspense fallback={null}>
+            <HostFormDialog
+              open={overlay?.type === "host-form"}
+              hostId={shownOverlay.hostId}
+              initialGroupId={shownOverlay.groupId}
+              onClose={closeOverlay}
+            />
+          </Suspense>
+        </ErrorBoundary>
       )}
       {shownOverlay?.type === "group-form" && (
-        <Suspense fallback={null}>
-          <GroupFormDialog
-            open={overlay?.type === "group-form"}
-            groupId={shownOverlay.groupId}
-            initialParentId={shownOverlay.parentId}
-            onClose={closeOverlay}
-          />
-        </Suspense>
+        <ErrorBoundary>
+          <Suspense fallback={null}>
+            <GroupFormDialog
+              open={overlay?.type === "group-form"}
+              groupId={shownOverlay.groupId}
+              initialParentId={shownOverlay.parentId}
+              onClose={closeOverlay}
+            />
+          </Suspense>
+        </ErrorBoundary>
       )}
       {shownOverlay?.type === "palette" && (
-        <Suspense fallback={null}>
-          <CommandPalette
-            open={overlay?.type === "palette"}
-            initialMode={shownOverlay.mode}
-            onClose={closeOverlay}
-          />
-        </Suspense>
+        <ErrorBoundary>
+          <Suspense fallback={null}>
+            <CommandPalette
+              open={overlay?.type === "palette"}
+              initialMode={shownOverlay.mode}
+              onClose={closeOverlay}
+            />
+          </Suspense>
+        </ErrorBoundary>
       )}
       {shownOverlay?.type === "settings" && (
-        <Suspense fallback={null}>
-          <SettingsDialog
-            open={overlay?.type === "settings"}
-            section={shownOverlay.section}
-            onSectionChange={setSettingsSection}
-            onClose={closeOverlay}
-          />
-        </Suspense>
+        <ErrorBoundary>
+          <Suspense fallback={null}>
+            <SettingsDialog
+              open={overlay?.type === "settings"}
+              section={shownOverlay.section}
+              onSectionChange={setSettingsSection}
+              onClose={closeOverlay}
+            />
+          </Suspense>
+        </ErrorBoundary>
       )}
       {hostKeyMounted && (
-        <Suspense fallback={null}>
-          <HostKeyDialog />
-        </Suspense>
+        <ErrorBoundary>
+          <Suspense fallback={null}>
+            <HostKeyDialog />
+          </Suspense>
+        </ErrorBoundary>
       )}
       {passwordMounted && (
-        <Suspense fallback={null}>
-          <PasswordPromptDialog />
-        </Suspense>
+        <ErrorBoundary>
+          <Suspense fallback={null}>
+            <PasswordPromptDialog />
+          </Suspense>
+        </ErrorBoundary>
       )}
-      <Suspense fallback={null}>
-        <UpdateNotifier />
-      </Suspense>
+      <ErrorBoundary>
+        <Suspense fallback={null}>
+          <UpdateNotifier />
+        </Suspense>
+      </ErrorBoundary>
       <LazyToaster />
     </div>
   );
@@ -411,9 +430,11 @@ function LazyToaster() {
   const hasToasts = useToastStore((state) => state.toasts.length > 0);
   if (!hasToasts) return null;
   return (
-    <Suspense fallback={null}>
-      <Toaster />
-    </Suspense>
+    <ErrorBoundary fallback={null}>
+      <Suspense fallback={null}>
+        <Toaster />
+      </Suspense>
+    </ErrorBoundary>
   );
 }
 

--- a/src/workbench/tray.ts
+++ b/src/workbench/tray.ts
@@ -33,8 +33,10 @@ export function useTrayMenu(): void {
   const lastPushed = useRef<string | null>(null);
 
   useEffect(() => {
-    void bridgeForwardEvents().catch(() => {});
-  }, []);
+    void bridgeForwardEvents().catch((error) =>
+      toast.error(t("forwards.statusError"), errorMessage(error)),
+    );
+  }, [t]);
 
   useEffect(() => {
     const push = () => {


### PR DESCRIPTION
## Summary

- add localized error boundaries for lazy-loaded UI and the application root
- recover pending SSH prompts and prevent stale SFTP, monitor, and terminal async work
- tighten cron validation, bound model metadata caching, and clean up transient timers
- add regression coverage for error recovery and lifecycle races

## Validation

- pnpm format:check
- pnpm check:conventions
- pnpm typecheck
- pnpm test
- pnpm lint
- pnpm build

Closes #51